### PR TITLE
[Lib][Aggregator] Fix AggregatorFactory Auto Registration Failure

### DIFF
--- a/base/serialization.hpp
+++ b/base/serialization.hpp
@@ -159,5 +159,12 @@ BinStream& operator>>(BinStream& stream, std::string& x);
 BinStream& operator<<(BinStream& stream, const std::vector<bool>& v);
 BinStream& operator>>(BinStream& stream, std::vector<bool>& v);
 
+template <typename Value>
+Value deser(BinStream& in) {
+    Value v;
+    in >> v;
+    return v;
+}
+
 }  // namespace base
 }  // namespace husky

--- a/lib/aggregator.cpp
+++ b/lib/aggregator.cpp
@@ -22,6 +22,7 @@
 
 #include "base/serialization.hpp"
 #include "core/utils.hpp"
+#include "lib/aggregator_factory.hpp"
 #include "lib/aggregator_object.hpp"
 
 namespace husky {
@@ -32,6 +33,15 @@ thread_local std::shared_ptr<AggregatorFactoryBase> AggregatorFactoryBase::facto
 AggregatorInfo::~AggregatorInfo() {
     if (value != nullptr)
         delete value;
+}
+
+AggregatorFactoryBase* AggregatorFactoryBase::create_factory() {
+    // use registered factory constructor to create a factory
+    auto& ctor = get_factory_constructor();
+    if (ctor == nullptr) {
+        ctor = []() { return new AggregatorFactory(); };
+    }
+    return ctor();
 }
 
 void AggregatorFactoryBase::init_factory() {

--- a/lib/aggregator.hpp
+++ b/lib/aggregator.hpp
@@ -134,12 +134,7 @@ class AggregatorFactoryBase {
         return factory_constructor;
     }
 
-    static AggregatorFactoryBase* create_factory() {
-        // use registered factory constructor to create a factory
-        auto ctor = get_factory_constructor();
-        ASSERT_MSG(ctor != nullptr, "No subclass of AggregatorFactoryBase registered");
-        return ctor();
-    }
+    static AggregatorFactoryBase* create_factory();
 
     // Assumption: each factory should create an aggregator together
     // i.e. the amount and the order of aggregators created by each factory must be the same
@@ -247,8 +242,8 @@ class Aggregator {
 
     void update(const ValueType& b) { local_agg_->aggregate(b); }
 
-    template <typename U>
-    void update(const std::function<void(ValueType&, const U&)>& lambda, const U& val) {
+    template <typename UpdateLambdaType, typename U>
+    void update(const UpdateLambdaType& lambda, const U& val) {
         lambda(local_agg_->get_value(), val);
     }
 

--- a/lib/aggregator_factory.cpp
+++ b/lib/aggregator_factory.cpp
@@ -32,8 +32,6 @@ using core::Accessor;
 using lib::AggregatorFactory;
 using lib::AggregatorState;
 
-AutoRegisterAggregatorFactory auto_reg_agg_factory;
-
 AggregatorChannel& AggregatorFactory::get_channel() { return static_cast<AggregatorFactory&>(get_factory()).channel(); }
 
 AggregatorChannel& AggregatorFactory::channel() { return aggregator_channel_; }
@@ -105,10 +103,6 @@ void AggregatorFactory::on_recv(AggregatorChannel& channel, const std::function<
             recv(bin);
         }
     }
-}
-
-AutoRegisterAggregatorFactory::AutoRegisterAggregatorFactory() {
-    AggregatorFactory::register_factory_constructor([]() { return new AggregatorFactory(); });
 }
 
 }  // namespace lib

--- a/lib/aggregator_factory.hpp
+++ b/lib/aggregator_factory.hpp
@@ -68,12 +68,5 @@ class AggregatorFactory : public AggregatorFactoryBase {
     AggregatorChannel aggregator_channel_;
 };
 
-class AutoRegisterAggregatorFactory {
-   public:
-    AutoRegisterAggregatorFactory();
-};
-
-extern AutoRegisterAggregatorFactory auto_reg_agg_factory;
-
 }  // namespace lib
 }  // namespace husky


### PR DESCRIPTION
Fix #65.

Make AggregatorFactory be a default registered factory of AggregatorFactoryBase. The solution works and still ensures one can register other factories, but it seems not perfect because this makes AggregatorFactoryBase depends on extra unnecessary classes.