### PR TITLE
[Core][ObjList] Mark some methods as protected

### DIFF
--- a/core/attrlist_unittest.cpp
+++ b/core/attrlist_unittest.cpp
@@ -17,7 +17,7 @@
 
 #include "gtest/gtest.h"
 
-#include "core/objlist.hpp"
+#include "core/objlist_unittest.hpp"
 
 namespace husky {
 namespace {
@@ -51,7 +51,7 @@ class AttrDb {
 };
 
 TEST_F(TestAttrList, InitAndGet) {
-    ObjList<Obj> obj_list;
+    ObjListForTest<Obj> obj_list;
     obj_list.create_attrlist<int>("int");
     obj_list.create_attrlist<AttrDb>("attr");
     auto& int_list = obj_list.get_attrlist<int>("int");
@@ -63,14 +63,14 @@ TEST_F(TestAttrList, InitAndGet) {
 }
 
 TEST_F(TestAttrList, InitAndDelete) {
-    ObjList<Obj> obj_list;
+    ObjListForTest<Obj> obj_list;
     obj_list.create_attrlist<int>("int");
     EXPECT_EQ(obj_list.del_attrlist("int"), 1);
     EXPECT_EQ(obj_list.del_attrlist("int"), 0);
 }
 
 TEST_F(TestAttrList, SetAttrAndGet) {
-    ObjList<Obj> obj_list;
+    ObjListForTest<Obj> obj_list;
     auto& intlist = obj_list.create_attrlist<int>("int");
     auto& attr_list = obj_list.create_attrlist<AttrDb>("attr");
     for (int i = 0; i < 10; ++i) {
@@ -105,7 +105,7 @@ TEST_F(TestAttrList, SetAttrAndGet) {
 }
 
 TEST_F(TestAttrList, Sort) {
-    ObjList<Obj> obj_list;
+    ObjListForTest<Obj> obj_list;
     auto& intlist = obj_list.create_attrlist<int>("int");
     for (int i = 0; i < 10; ++i) {
         Obj obj(10 - i - 1);  // insert obj by descending order
@@ -116,7 +116,7 @@ TEST_F(TestAttrList, Sort) {
         EXPECT_EQ(intlist[i], i);
     }
 
-    obj_list.sort();
+    obj_list.test_sort();
 
     for (int i = 0; i < 10; ++i) {
         EXPECT_EQ(intlist[i], 10 - i - 1);
@@ -124,7 +124,7 @@ TEST_F(TestAttrList, Sort) {
 }
 
 TEST_F(TestAttrList, DeleteAndSort) {
-    ObjList<Obj> obj_list;
+    ObjListForTest<Obj> obj_list;
     auto& intlist = obj_list.create_attrlist<int>("int");
     auto& attr_list = obj_list.create_attrlist<AttrDb>("attr");
     for (int i = 0; i < 10; ++i) {
@@ -138,11 +138,11 @@ TEST_F(TestAttrList, DeleteAndSort) {
     Obj* p2 = &v[7];
     obj_list.delete_object(p);
     obj_list.delete_object(p2);
-    EXPECT_EQ(obj_list.get_num_del(), 2);
+    EXPECT_EQ(obj_list.test_get_num_del(), 2);
     EXPECT_EQ(obj_list.get_del(3), 1);
     EXPECT_EQ(obj_list.get_del(5), 0);
 
-    obj_list.deletion_finalize();
+    obj_list.test_deletion_finalize();
 
     // check size
     EXPECT_EQ(intlist.size(), 8);
@@ -153,7 +153,7 @@ TEST_F(TestAttrList, DeleteAndSort) {
     EXPECT_DOUBLE_EQ(attr_list[3].val, 9.0);
     EXPECT_DOUBLE_EQ(attr_list[7].val, 8.0);
 
-    obj_list.sort();
+    obj_list.test_sort();
 
     EXPECT_EQ(v[3].key, 4);
     EXPECT_EQ(v[7].key, 9);

--- a/core/channel/async_migrate_channel_unittest.cpp
+++ b/core/channel/async_migrate_channel_unittest.cpp
@@ -8,7 +8,7 @@
 #include "base/serialization.hpp"
 #include "core/hash_ring.hpp"
 #include "core/mailbox.hpp"
-#include "core/objlist.hpp"
+#include "core/objlist_unittest.hpp"
 #include "core/worker_info.hpp"
 
 namespace husky {
@@ -43,7 +43,7 @@ class Attr {
 
 // Create AsyncMigrateChannel without setting, for setup
 template <typename ObjT>
-AsyncMigrateChannel<ObjT> create_async_migrate_channel(ObjList<ObjT>& obj_list) {
+AsyncMigrateChannel<ObjT> create_async_migrate_channel(ObjListForTest<ObjT>& obj_list) {
     AsyncMigrateChannel<ObjT> async_migrate_channel(&obj_list);
     return async_migrate_channel;
 }
@@ -71,7 +71,7 @@ TEST_F(TestAsyncMigrateChannel, Create) {
     workerinfo.set_proc_id(0);
 
     // ObjList Setup
-    ObjList<Obj> obj_list;
+    ObjListForTest<Obj> obj_list;
 
     // AsyncMigrateChannel
     auto async_migrate_channel = create_async_migrate_channel(obj_list);
@@ -101,7 +101,7 @@ TEST_F(TestAsyncMigrateChannel, MigrateOtherIncProgress) {
     workerinfo.set_proc_id(0);
 
     // ObjList Setup
-    ObjList<Obj> obj_list;
+    ObjListForTest<Obj> obj_list;
 
     auto& scr_int = obj_list.create_attrlist<int>("int");
     auto& src_attr = obj_list.create_attrlist<Attr>("attr");
@@ -118,7 +118,7 @@ TEST_F(TestAsyncMigrateChannel, MigrateOtherIncProgress) {
     Obj* p = obj_list.find(100);
     async_migrate_channel.migrate(*p, 0);  // migrate Obj(18) to thread 0
     async_migrate_channel.out();
-    obj_list.deletion_finalize();
+    obj_list.test_deletion_finalize();
     // migration done
     while (
         mailbox.poll_with_timeout(async_migrate_channel.get_channel_id(), async_migrate_channel.get_progress(), 1.0)) {
@@ -142,7 +142,7 @@ TEST_F(TestAsyncMigrateChannel, MigrateOtherIncProgress) {
     p = obj_list.find(57);
     async_migrate_channel.migrate(*p, 0);  // migrate Obj(57) to thread 0
     async_migrate_channel.out();
-    obj_list.deletion_finalize();
+    obj_list.test_deletion_finalize();
     // migration done
     while (
         mailbox.poll_with_timeout(async_migrate_channel.get_channel_id(), async_migrate_channel.get_progress(), 1.0)) {

--- a/core/channel/async_push_channel_unittest.cpp
+++ b/core/channel/async_push_channel_unittest.cpp
@@ -11,7 +11,7 @@
 #include "core/channel/migrate_channel.hpp"
 #include "core/hash_ring.hpp"
 #include "core/mailbox.hpp"
-#include "core/objlist.hpp"
+#include "core/objlist_unittest.hpp"
 #include "core/worker_info.hpp"
 
 namespace husky {
@@ -38,13 +38,13 @@ class Obj {
 
 // Create AsyncPushChannel without setting
 template <typename MsgT, typename DstObjT>
-AsyncPushChannel<MsgT, DstObjT> create_async_push_channel(ObjList<DstObjT>& obj_list) {
+AsyncPushChannel<MsgT, DstObjT> create_async_push_channel(ObjListForTest<DstObjT>& obj_list) {
     AsyncPushChannel<MsgT, DstObjT> async_push_channel(&obj_list);
     return async_push_channel;
 }
 // Create MigrateChannel without setting
 template <typename ObjT>
-MigrateChannel<ObjT> create_migrate_channel(ObjList<ObjT>& src_list, ObjList<ObjT>& dst_list) {
+MigrateChannel<ObjT> create_migrate_channel(ObjListForTest<ObjT>& src_list, ObjListForTest<ObjT>& dst_list) {
     MigrateChannel<ObjT> migrate_channel(&src_list, &dst_list);
     return migrate_channel;
 }
@@ -72,7 +72,7 @@ TEST_F(TestAsyncPushChannel, Create) {
     workerinfo.set_proc_id(0);
 
     // ObjList Setup
-    ObjList<Obj> obj_list;
+    ObjListForTest<Obj> obj_list;
 
     // PushChannel
     auto async_push_channel = create_async_push_channel<int>(obj_list);
@@ -102,7 +102,7 @@ TEST_F(TestAsyncPushChannel, PushSingle) {
     workerinfo.set_proc_id(0);
 
     // ObjList Setup
-    ObjList<Obj> obj_list;
+    ObjListForTest<Obj> obj_list;
 
     // PushChannel
     auto async_push_channel = create_async_push_channel<int>(obj_list);
@@ -135,7 +135,7 @@ TEST_F(TestAsyncPushChannel, PushMultipleTime) {
     el.register_mailbox(mailbox);
 
     // ObjList Setup
-    ObjList<Obj> obj_list;
+    ObjListForTest<Obj> obj_list;
 
     // WorkerInfo Setup
     WorkerInfo workerinfo;
@@ -194,7 +194,7 @@ TEST_F(TestAsyncPushChannel, IncProgress) {
     workerinfo.set_proc_id(0);
 
     // ObjList Setup
-    ObjList<Obj> obj_list;
+    ObjListForTest<Obj> obj_list;
 
     // PushChannel
     // Round 1
@@ -254,7 +254,7 @@ TEST_F(TestAsyncPushChannel, MultiThread) {
     workerinfo.set_proc_id(0);
 
     std::thread th1 = std::thread([&]() {
-        ObjList<Obj> obj_list;
+        ObjListForTest<Obj> obj_list;
 
         obj_list.add_object(Obj(100));
         obj_list.add_object(Obj(18));
@@ -269,10 +269,10 @@ TEST_F(TestAsyncPushChannel, MultiThread) {
                 migrate_channel.migrate(obj, dst_thread_id);
             }
         }
-        obj_list.deletion_finalize();
+        obj_list.test_deletion_finalize();
         migrate_channel.out();
         migrate_channel.prepare_immigrants();
-        obj_list.sort();
+        obj_list.test_sort();
 
         // Push
         auto async_push_channel = create_async_push_channel<int>(obj_list);
@@ -293,7 +293,7 @@ TEST_F(TestAsyncPushChannel, MultiThread) {
         }
     });
     std::thread th2 = std::thread([&]() {
-        ObjList<Obj> obj_list;
+        ObjListForTest<Obj> obj_list;
 
         obj_list.add_object(Obj(1));
         obj_list.add_object(Obj(1342148));
@@ -308,10 +308,10 @@ TEST_F(TestAsyncPushChannel, MultiThread) {
                 migrate_channel.migrate(obj, dst_thread_id);
             }
         }
-        obj_list.deletion_finalize();
+        obj_list.test_deletion_finalize();
         migrate_channel.out();
         migrate_channel.prepare_immigrants();
-        obj_list.sort();
+        obj_list.test_sort();
 
         // Push
         auto async_push_channel = create_async_push_channel<int>(obj_list);

--- a/core/channel/push_channel_unittest.cpp
+++ b/core/channel/push_channel_unittest.cpp
@@ -11,7 +11,7 @@
 #include "core/channel/migrate_channel.hpp"
 #include "core/hash_ring.hpp"
 #include "core/mailbox.hpp"
-#include "core/objlist.hpp"
+#include "core/objlist_unittest.hpp"
 #include "core/worker_info.hpp"
 
 namespace husky {
@@ -38,13 +38,13 @@ class Obj {
 
 // Create PushChannel without setting
 template <typename MsgT, typename DstObjT>
-PushChannel<MsgT, DstObjT> create_push_channel(ChannelSource& src_list, ObjList<DstObjT>& dst_list) {
+PushChannel<MsgT, DstObjT> create_push_channel(ChannelSource& src_list, ObjListForTest<DstObjT>& dst_list) {
     PushChannel<MsgT, DstObjT> push_channel(&src_list, &dst_list);
     return push_channel;
 }
 // Create MigrateChannel without setting
 template <typename ObjT>
-MigrateChannel<ObjT> create_migrate_channel(ObjList<ObjT>& src_list, ObjList<ObjT>& dst_list) {
+MigrateChannel<ObjT> create_migrate_channel(ObjListForTest<ObjT>& src_list, ObjListForTest<ObjT>& dst_list) {
     MigrateChannel<ObjT> migrate_channel(&src_list, &dst_list);
     return migrate_channel;
 }
@@ -72,8 +72,8 @@ TEST_F(TestPushChannel, Create) {
     workerinfo.set_proc_id(0);
 
     // ObjList Setup
-    ObjList<Obj> src_list;
-    ObjList<Obj> dst_list;
+    ObjListForTest<Obj> src_list;
+    ObjListForTest<Obj> dst_list;
 
     // PushChannel
     auto push_channel = create_push_channel<int>(src_list, dst_list);
@@ -103,8 +103,8 @@ TEST_F(TestPushChannel, PushSingle) {
     workerinfo.set_proc_id(0);
 
     // ObjList Setup
-    ObjList<Obj> src_list;
-    ObjList<Obj> dst_list;
+    ObjListForTest<Obj> src_list;
+    ObjListForTest<Obj> dst_list;
 
     // PushChannel
     auto push_channel = create_push_channel<int>(src_list, dst_list);
@@ -137,8 +137,8 @@ TEST_F(TestPushChannel, PushMultipleTime) {
     el.register_mailbox(mailbox);
 
     // ObjList Setup
-    ObjList<Obj> src_list;
-    ObjList<Obj> dst_list;
+    ObjListForTest<Obj> src_list;
+    ObjListForTest<Obj> dst_list;
 
     // WorkerInfo Setup
     WorkerInfo workerinfo;
@@ -192,8 +192,8 @@ TEST_F(TestPushChannel, IncProgress) {
     workerinfo.set_proc_id(0);
 
     // ObjList Setup
-    ObjList<Obj> src_list;
-    ObjList<Obj> dst_list;
+    ObjListForTest<Obj> src_list;
+    ObjListForTest<Obj> dst_list;
 
     // PushChannel
     // Round 1
@@ -253,7 +253,7 @@ TEST_F(TestPushChannel, MultiThread) {
     workerinfo.set_proc_id(0);
 
     std::thread th1 = std::thread([&]() {
-        ObjList<Obj> src_list;
+        ObjListForTest<Obj> src_list;
 
         src_list.add_object(Obj(100));
         src_list.add_object(Obj(18));
@@ -268,10 +268,10 @@ TEST_F(TestPushChannel, MultiThread) {
                 migrate_channel.migrate(obj, dst_thread_id);
             }
         }
-        src_list.deletion_finalize();
+        src_list.test_deletion_finalize();
         migrate_channel.flush();
         migrate_channel.prepare_immigrants();
-        src_list.sort();
+        src_list.test_sort();
 
         // Push
         auto push_channel = create_push_channel<int>(src_list, src_list);
@@ -292,7 +292,7 @@ TEST_F(TestPushChannel, MultiThread) {
         }
     });
     std::thread th2 = std::thread([&]() {
-        ObjList<Obj> src_list;
+        ObjListForTest<Obj> src_list;
 
         src_list.add_object(Obj(1));
         src_list.add_object(Obj(1342148));
@@ -307,10 +307,10 @@ TEST_F(TestPushChannel, MultiThread) {
                 migrate_channel.migrate(obj, dst_thread_id);
             }
         }
-        src_list.deletion_finalize();
+        src_list.test_deletion_finalize();
         migrate_channel.flush();
         migrate_channel.prepare_immigrants();
-        src_list.sort();
+        src_list.test_sort();
 
         // Push
         auto push_channel = create_push_channel<int>(src_list, src_list);

--- a/core/objlist_unittest.cpp
+++ b/core/objlist_unittest.cpp
@@ -1,4 +1,4 @@
-#include "core/objlist.hpp"
+#include "core/objlist_unittest.hpp"
 
 #include <string>
 #include <vector>
@@ -28,13 +28,13 @@ class Obj {
 };
 
 TEST_F(TestObjList, InitAndDelete) {
-    ObjList<Obj>* obj_list = new ObjList<Obj>();
+    ObjListForTest<Obj>* obj_list = new ObjListForTest<Obj>();
     ASSERT_TRUE(obj_list != nullptr);
     delete obj_list;
 }
 
 TEST_F(TestObjList, AddObject) {
-    ObjList<Obj> obj_list;
+    ObjListForTest<Obj> obj_list;
     for (int i = 0; i < 10; ++i) {
         Obj obj(i);
         obj_list.add_object(obj);
@@ -46,7 +46,7 @@ TEST_F(TestObjList, AddObject) {
 }
 
 TEST_F(TestObjList, AddMoveObject) {
-    ObjList<Obj> obj_list;
+    ObjListForTest<Obj> obj_list;
     for (int i = 0; i < 10; ++i) {
         Obj obj(i);
         obj_list.add_object(std::move(obj));
@@ -58,15 +58,15 @@ TEST_F(TestObjList, AddMoveObject) {
 }
 
 TEST_F(TestObjList, Sort) {
-    ObjList<Obj> obj_list;
+    ObjListForTest<Obj> obj_list;
     for (int i = 0; i < 10; ++i) {
         Obj obj(10 - i - 1);
         obj_list.add_object(std::move(obj));
     }
-    obj_list.sort();
-    EXPECT_EQ(obj_list.get_sorted_size(), 10);
-    EXPECT_EQ(obj_list.get_num_del(), 0);
-    EXPECT_EQ(obj_list.get_hashed_size(), 0);
+    obj_list.test_sort();
+    EXPECT_EQ(obj_list.test_get_sorted_size(), 10);
+    EXPECT_EQ(obj_list.test_get_num_del(), 0);
+    EXPECT_EQ(obj_list.test_get_hashed_size(), 0);
     EXPECT_EQ(obj_list.get_size(), 10);
     std::vector<Obj>& v = obj_list.get_data();
     for (int i = 0; i < 10; ++i) {
@@ -75,7 +75,7 @@ TEST_F(TestObjList, Sort) {
 }
 
 TEST_F(TestObjList, Delete) {
-    ObjList<Obj> obj_list;
+    ObjListForTest<Obj> obj_list;
     for (int i = 0; i < 10; ++i) {
         Obj obj(i);
         obj_list.add_object(std::move(obj));
@@ -85,16 +85,16 @@ TEST_F(TestObjList, Delete) {
     Obj* p2 = &v[7];
     obj_list.delete_object(p);
     obj_list.delete_object(p2);
-    EXPECT_EQ(obj_list.get_num_del(), 2);
+    EXPECT_EQ(obj_list.test_get_num_del(), 2);
     EXPECT_EQ(obj_list.get_del(3), 1);
     EXPECT_EQ(obj_list.get_del(5), 0);
-    obj_list.deletion_finalize();
-    EXPECT_EQ(obj_list.get_num_del(), 0);
+    obj_list.test_deletion_finalize();
+    EXPECT_EQ(obj_list.test_get_num_del(), 0);
     EXPECT_EQ(obj_list.get_size(), 8);
 }
 
 TEST_F(TestObjList, Find) {
-    ObjList<Obj> obj_list;
+    ObjListForTest<Obj> obj_list;
     for (int i = 0; i < 10; ++i) {
         Obj obj(i);
         obj_list.add_object(std::move(obj));
@@ -102,7 +102,7 @@ TEST_F(TestObjList, Find) {
     EXPECT_NE(obj_list.find(3), nullptr);
     EXPECT_NE(obj_list.find(5), nullptr);
     EXPECT_EQ(obj_list.find(10), nullptr);
-    obj_list.sort();
+    obj_list.test_sort();
     EXPECT_NE(obj_list.find(3), nullptr);
     EXPECT_NE(obj_list.find(5), nullptr);
     EXPECT_EQ(obj_list.find(10), nullptr);

--- a/core/objlist_unittest.hpp
+++ b/core/objlist_unittest.hpp
@@ -1,0 +1,27 @@
+#include "core/objlist.hpp"
+
+#pragma once
+
+namespace husky {
+
+template <typename ObjT>
+class ObjListForTest : public ::husky::ObjList<ObjT> {
+   public:
+    void test_deletion_finalize() {
+        ObjList<ObjT>::deletion_finalize();
+    }
+    void test_sort() {
+        ObjList<ObjT>::sort();
+    }
+    size_t test_get_sorted_size() const {
+        return ObjList<ObjT>::get_sorted_size();
+    }
+    size_t test_get_num_del() const {
+        return ObjList<ObjT>::get_num_del();
+    }
+    size_t test_get_hashed_size() const {
+        return ObjList<ObjT>::get_hashed_size();
+    }
+};
+
+}  // namespace husky


### PR DESCRIPTION
This is for better encapsulation, since users normally won't touch these low-level methods.