### PR TITLE
[Core][Mailbox] Minor adjustment of the send_complete method

### DIFF
--- a/core/hash_ring.hpp
+++ b/core/hash_ring.hpp
@@ -45,6 +45,8 @@ class HashRing {
 
     std::vector<int>& get_global_pids() { return global_pids_vector_; }
 
+    std::vector<int>& get_global_tids() { return global_tids_vector_; }
+
     int get_num_processes() { return global_pids_vector_.size(); }
 
     int get_num_local_threads(int pid) { return num_local_threads_[pid]; }


### PR DESCRIPTION
This is to facilitate cross-cluster communication using Channels. Also, the hash rings are no longer fully copied. Mailbox will only copy the necessary parts.

This PR is related to issue #76 .