### PR TITLE
[Core][Channel] Drop all channels at the end of a session

### DIFF
--- a/core/channel/channel_factory_base.cpp
+++ b/core/channel/channel_factory_base.cpp
@@ -17,10 +17,14 @@
 #include <string>
 #include <unordered_map>
 
+#include "base/session_local.hpp"
+
 namespace husky {
 
 thread_local int ChannelFactoryBase::default_channel_id = 0;
 thread_local std::unordered_map<std::string, ChannelBase*> ChannelFactoryBase::channel_map;
 const char* ChannelFactoryBase::channel_name_prefix = "default_channel_";
+
+static thread_local base::RegSessionThreadFinalizer finalize_all_channels([]() { ChannelFactoryBase::drop_all_channels(); });
 
 }  // namespace husky

--- a/core/channel/channel_factory_base.hpp
+++ b/core/channel/channel_factory_base.hpp
@@ -163,6 +163,13 @@ class ChannelFactoryBase {
 
     static size_t size() { return channel_map.size(); }
 
+    static void drop_all_channels() {
+        for (auto& channel_pair : channel_map) {
+            delete channel_pair.second;
+        }
+        channel_map.clear();
+    }
+
    protected:
     static thread_local std::unordered_map<std::string, ChannelBase*> channel_map;
     static thread_local int default_channel_id;

--- a/core/channel/push_combined_channel.hpp
+++ b/core/channel/push_combined_channel.hpp
@@ -45,7 +45,8 @@ class PushCombinedChannel : public Source2ObjListChannel<DstObjT> {
     ~PushCombinedChannel() override {
         ShuffleCombinerFactory::remove_shuffle_combiner(this->channel_id_);
 
-        this->src_ptr_->deregister_outchannel(this->channel_id_);
+        // TODO(Louis): to design a factory for input formats
+        // this->src_ptr_->deregister_outchannel(this->channel_id_);
         this->dst_ptr_->deregister_inchannel(this->channel_id_);
     }
 

--- a/core/job_runner.cpp
+++ b/core/job_runner.cpp
@@ -22,6 +22,7 @@
 
 #include "base/log.hpp"
 #include "base/serialization.hpp"
+#include "base/session_local.hpp"
 #include "core/config.hpp"
 #include "core/constants.hpp"
 #include "core/context.hpp"
@@ -62,6 +63,7 @@ void run_job(const std::function<void()>& job) {
     // Initialize coordinator
     Context::get_coordinator().serve();
 
+    base::SessionLocal::initialize();
     // Initialize worker threads
     std::vector<boost::thread*> threads;
     int local_id = 0;
@@ -77,6 +79,7 @@ void run_job(const std::function<void()>& job) {
 
             job();
 
+            base::SessionLocal::thread_finalize();
             Context::finalize_local();
 
             base::BinStream finish_signal;
@@ -95,6 +98,7 @@ void run_job(const std::function<void()>& job) {
     for (int i = 0; i < threads.size(); i++)
         delete mailboxes[i];
 
+    base::SessionLocal::finalize();
     Context::finalize_global();
 }
 


### PR DESCRIPTION
Fix #104.

Use session_local to finalize all the channels inside `finalize_global()`
