### PR TITLE
[Examples] Rewrite PIC example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -123,3 +123,9 @@ add_executable(TF-IDF tfidf.cpp)
 target_link_libraries(TF-IDF ${husky})
 target_link_libraries(TF-IDF ${EXTERNAL_LIB})
 set_property(TARGET Aggregator PROPERTY CXX_STANDARD 14)
+
+# Affinity matrix
+add_executable(AMAT affinity.cpp)
+target_link_libraries(AMAT ${husky})
+target_link_libraries(AMAT ${EXTERNAL_LIB})
+set_property(TARGET AMAT PROPERTY CXX_STANDARD 14)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -64,6 +64,12 @@ target_link_libraries(CC ${husky})
 target_link_libraries(CC ${EXTERNAL_LIB})
 set_property(TARGET CC PROPERTY CXX_STANDARD 14)
 
+# PIC
+add_executable(PIC pic.cpp)
+target_link_libraries(PIC ${husky})
+target_link_libraries(PIC ${EXTERNAL_LIB})
+set_property(TARGET PIC PROPERTY CXX_STANDARD 14)
+
 # PageRank
 add_executable(PageRank pagerank.cpp)
 target_link_libraries(PageRank ${husky})

--- a/examples/affinity.cpp
+++ b/examples/affinity.cpp
@@ -1,0 +1,225 @@
+// Copyright 2016 Husky Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <random>
+#include <string>
+#include <vector>
+
+#include "boost/tokenizer.hpp"
+
+#include "core/engine.hpp"
+#include "io/hdfs_manager.hpp"
+#include "io/input/line_inputformat.hpp"
+#include "lib/aggregator_factory.hpp"
+
+#include "lib/vector.hpp"
+
+typedef husky::lib::DenseVector<float> ndvec;
+
+class NDpoint {
+    // N-dimension point modelling the input data
+   public:
+    using KeyT = int;
+
+    NDpoint() {}
+    explicit NDpoint(const KeyT& w) : pointId(w) {}
+    NDpoint(const KeyT& pId, ndvec coords) {
+        this->pointId = pId;
+        this->coords = std::move(coords);
+    }
+    virtual const KeyT& id() const { return pointId; }
+
+    // Serialization and deserialization
+    friend husky::BinStream& operator<<(husky::BinStream& stream, NDpoint u) {
+        stream << u.pointId << u.coords;
+        return stream;
+    }
+    friend husky::BinStream& operator>>(husky::BinStream& stream, NDpoint& u) {
+        stream >> u.pointId >> u.coords;
+        return stream;
+    }
+
+    int pointId;
+    ndvec coords;
+};
+
+class MatElem {
+    // Matrix elemet for the affinity matrix
+   public:
+    using KeyT = uint;
+
+    MatElem() {}
+    explicit MatElem(const KeyT& p) : pos(p) {}
+    virtual const KeyT& id() const { return pos; }
+
+    // Serialization and deserialization
+    friend husky::BinStream& operator<<(husky::BinStream& stream, MatElem u) {
+        stream << u.pos << u.val;
+        return stream;
+    }
+    friend husky::BinStream& operator>>(husky::BinStream& stream, MatElem& u) {
+        stream >> u.pos >> u.val;
+        return stream;
+    }
+
+    KeyT pos;
+    float val;
+};
+
+class MatRow {
+    // Dummy obj to collect Matrix elemet for the affinity matrix
+   public:
+    using KeyT = uint;
+
+    MatRow() {}
+    explicit MatRow(const KeyT& p) : pos(p) {}
+    virtual const KeyT& id() const { return pos; }
+
+    // Serialization and deserialization
+    friend husky::BinStream& operator<<(husky::BinStream& stream, MatRow u) {
+        stream << u.pos;
+        return stream;
+    }
+    friend husky::BinStream& operator>>(husky::BinStream& stream, MatRow& u) {
+        stream >> u.pos;
+        return stream;
+    }
+
+    KeyT pos;
+};
+
+void affinity() {
+    husky::io::LineInputFormat infmt;
+    infmt.set_input(husky::Context::get_param("input"));
+
+    int dimension = std::stoi(husky::Context::get_param("dimension"));
+
+    // for calculating mean(x_i  ) for each dimension i in input data
+    husky::lib::Aggregator<ndvec> dataxAgg(ndvec(dimension, 0.), [](ndvec& a, const ndvec& b) { a += b; },
+                                           [&](ndvec& v) { v = std::move(ndvec(dimension, 0.)); });
+
+    // for calculating mean(x_i^2) for each dimension i in input data
+    husky::lib::Aggregator<ndvec> dataxxAgg(ndvec(dimension, 0.), [](ndvec& a, const ndvec& b) { a += b; },
+                                            [&](ndvec& v) { v = std::move(ndvec(dimension, 0.)); });
+
+    husky::lib::Aggregator<int> dataCountAgg;  // total no. of rows in input
+    auto& ac = husky::lib::AggregatorFactory::get_channel();
+
+    // 1. Create and globalize ndpoint objects
+    auto& ndpoint_list = husky::ObjListFactory::create_objlist<NDpoint>();
+    ndvec coordsSq(dimension);
+    auto parse_ndpoint = [&](boost::string_ref& chunk) {
+        if (chunk.size() == 0)
+            return;
+        boost::char_separator<char> sep(" \t");
+        boost::tokenizer<boost::char_separator<char>> tok(chunk, sep);
+        boost::tokenizer<boost::char_separator<char>>::iterator it = tok.begin();
+        int id = stoi(*it++);
+        ndvec coords(dimension);
+        for (int i = 0; i < dimension; i++) {
+            coords[i] = stod(*it++);
+            coordsSq[i] = coords[i] * coords[i];
+        }
+        dataCountAgg.update(1);
+        dataxAgg.update(coords);
+        dataxxAgg.update(coordsSq);
+        ndpoint_list.add_object(NDpoint(id, coords));
+    };
+    load(infmt, {&ac}, parse_ndpoint);
+    globalize(ndpoint_list);
+    husky::base::log_msg("No. of rows in input " + std::to_string(dataCountAgg.get_value()));
+
+    // 2. calculate the variance used in similarity function
+    size_t totDataPoints = dataCountAgg.get_value();
+    ndvec dataMean = dataxAgg.get_value() / totDataPoints;
+    ndvec dataVar = dataxxAgg.get_value() / totDataPoints;
+    // Var(x) = <x^2> - <x><x>
+    for (int i = 0; i < dimension; ++i) {
+        dataVar[i] -= dataMean[i] * dataMean[i];
+        husky::base::log_msg("var " + std::to_string(i) + " " + std::to_string(dataVar[i]));
+    }
+
+    // 3. calculate the affinity matrix
+    husky::ObjList<MatElem> affMatElem_list;
+    globalize(affMatElem_list);
+    auto& pairCh = husky::ChannelFactory::create_push_channel<NDpoint>(ndpoint_list, affMatElem_list);
+
+    // push 2 data points to each matrix element above the diagonal
+    list_execute(ndpoint_list, [&](NDpoint& p) {
+        // the pid-th col
+        for (uint i = 0; i < p.id(); ++i) {
+            pairCh.push(p, i * totDataPoints + p.id());
+        }
+        // the pid-th row
+        for (uint i = p.id() + 1; i < totDataPoints; ++i) {
+            pairCh.push(p, p.id() * totDataPoints + i);
+        }
+    });
+
+    husky::base::log_msg("affMat size " + std::to_string(affMatElem_list.get_size()));
+
+    husky::ObjList<MatRow> affMatRow_list;
+    auto& elemToRowCh = husky::ChannelFactory::create_push_channel<MatElem>(affMatElem_list, affMatRow_list);
+
+    // group matrix elements to rows
+    list_execute(affMatElem_list, [&](MatElem& e) {
+        auto pts = pairCh.get(e);
+        float nSigmaSq = 0;
+        for (uint i = 0; i < dimension; i++) {
+            nSigmaSq += pow(pts[0].coords[i] - pts[1].coords[i], 2) / (2. * dataVar[i]);
+        }
+        e.val = exp(-nSigmaSq);
+        int col = e.id() % totDataPoints;
+        int row = e.id() / totDataPoints;
+        // As affinity matrix is symmetric, each matrix element above the diagonal "belongs" to 2 rows
+        elemToRowCh.push(e, col);
+        elemToRowCh.push(e, row);
+    });
+
+    // 4. print output
+    list_execute(affMatRow_list, [&](MatRow& r) {
+        auto elems = elemToRowCh.get(r);
+        std::vector<float> rowVec(totDataPoints);
+        for (auto aElem : elems) {
+            int elemCol = aElem.id() % totDataPoints;
+            int elemRow = aElem.id() / totDataPoints;
+            if (elemCol > r.id())
+                rowVec[elemCol] = aElem.val;
+            else
+                rowVec[elemRow] = aElem.val;
+        }
+        std::string log;
+        log = std::to_string(r.id());
+        for (auto aElem : rowVec) {
+            log += "  " + std::to_string(aElem);
+        }
+        log += "\n";
+        husky::io::HDFS::Write("master", "9000", log, husky::Context::get_param("outDir"),
+                               husky::Context::get_global_tid());
+    });
+}
+
+int main(int argc, char** argv) {
+    std::vector<std::string> args;
+    args.push_back("hdfs_namenode");
+    args.push_back("hdfs_namenode_port");
+    args.push_back("input");
+    args.push_back("outDir");
+    args.push_back("dimension");
+    if (husky::init_with_args(argc, argv, args)) {
+        husky::run_job(affinity);
+        return 0;
+    }
+    return 1;
+}

--- a/examples/affinity.cpp
+++ b/examples/affinity.cpp
@@ -211,12 +211,24 @@ void affinity() {
 }
 
 int main(int argc, char** argv) {
+    // Input:
+    // A txt with the each line as
+    // pointID dim1Value dim2Value dim3Value ...
+    // eg.
+    // 0 -2.4903068672 3.13023508816
+    // 1 -0.788251940489 6.95547689798
+    // 2 -1.11412555846 6.91076871556
+    // ...
+    //
+    // Output:
+    // A txt with each line containing 1 row of the affinity matrix as
+    // rowID rowElem1 rowElem2 rowElem3 ...rowElemN
     std::vector<std::string> args;
     args.push_back("hdfs_namenode");
     args.push_back("hdfs_namenode_port");
-    args.push_back("input");
-    args.push_back("outDir");
-    args.push_back("dimension");
+    args.push_back("input");     // path to input file eg. hdfs:///user/ylchan/testPICdata.txt
+    args.push_back("outDir");    // output dir in hdfs eg. /user/ylchan/AffMat_T2/
+    args.push_back("dimension"); // number of dimensions for the input data
     if (husky::init_with_args(argc, argv, args)) {
         husky::run_job(affinity);
         return 0;

--- a/examples/pic.cpp
+++ b/examples/pic.cpp
@@ -20,36 +20,11 @@
 
 #include "core/engine.hpp"
 #include "io/input/hdfs_line_inputformat.hpp"
+#include "lib/aggregator_factory.hpp"
 
-void normalize(std::vector<double> &f, double rowsum) {
-        for (auto & x : f) {
-                    x /= rowsum;
-                        }
-}
-
-double magnitude(std::vector<double> &a) {
-        double sum = 0.0;
-            for (auto & x : a) {
-                        sum += pow(x, 2);
-                            }
-                return sqrt(sum);
-}
-
-double difference(std::vector<double> &a, std::vector<double> &b) {
-        double sum = 0.0;
-            int size = a.size();
-                for (int i = 0; i < size; ++i) {
-                            sum += pow(a[i] - b[i], 2);
-                                }
-                    return sum;
-}
-
-double similarity(std::vector<double> &a, std::vector<double> &b, double var) {
-        double S_ab = exp(-(difference(a, b))/(2 * var));
-            return S_ab;
-}
 
 class NDpoint {
+   //N-dimension point modelling the input data
    public:
     using KeyT = int;
 
@@ -75,7 +50,68 @@ class NDpoint {
     std::vector<float> coords;
 };
 
+class MatElem {
+   //Matrix elemet for the affinity matrix
+   public:
+    //using KeyT = std::pair<uint, uint>; // std::hash don't like std::pair
+    using KeyT = uint;
+
+    MatElem() {}
+    explicit MatElem(const KeyT& p) : pos(p) {}
+    virtual const KeyT& id() const { return pos; }
+
+    // Serialization and deserialization
+    friend husky::BinStream& operator<<(husky::BinStream& stream, MatElem u) {
+        stream << u.pos << u.val;
+        return stream;
+    }
+    friend husky::BinStream& operator>>(husky::BinStream& stream, MatElem& u) {
+        stream >> u.pos >> u.val;
+        return stream;
+    }
+
+    KeyT pos;
+    float val;
+};
+
+class VElem {
+   //Element for the classification vector V
+   public:
+    //using KeyT = std::pair<uint, uint>; // std::hash don't like std::pair
+    using KeyT = int;
+
+    VElem() {}
+    explicit VElem(const KeyT& p) : pos(p), val(0.), valp(0.), valpp(0.) {}
+    virtual const KeyT& id() const { return pos; }
+
+    // Serialization and deserialization
+    friend husky::BinStream& operator<<(husky::BinStream& stream, VElem u) {
+        stream << u.pos << u.val << u.valp << u.valpp;
+        return stream;
+    }
+    friend husky::BinStream& operator>>(husky::BinStream& stream, VElem& u) {
+        stream >> u.pos >> u.val >> u.valp >> u.valpp;
+        return stream;
+    }
+
+    KeyT pos;
+    float val;
+    float valp;  //val at previous iteration
+    float valpp; //val at previousX2 iteration
+
+    void setVal(float newval){
+        valpp = valp;
+        valp  = val;
+        val   = newval;
+    }
+
+    float getAcc(){
+        return fabs(fabs(val-valp) - fabs(valp-valpp));
+    }
+};
+
 class DimStat {
+   //Dimension statistics
    public:
     using KeyT = int;
 
@@ -83,20 +119,21 @@ class DimStat {
     explicit DimStat(const KeyT& w) : dimId(w) {}
     virtual const KeyT& id() const { return dimId; }
 
+    // Serialization and deserialization
+    friend husky::BinStream& operator<<(husky::BinStream& stream, DimStat u) {
+        stream << u.dimId << u.mean << u.var;
+        return stream;
+    }
+    friend husky::BinStream& operator>>(husky::BinStream& stream, DimStat& u) {
+        stream >> u.dimId >> u.mean >> u.var;
+        return stream;
+    }
+
     int dimId;
     float mean;
     float var;
 };
 
-class PIObject {
-   public:
-    typedef int KeyT;
-    int key;
-
-    explicit PIObject(KeyT key) { this->key = key; }
-
-    const int& id() const { return key; }
-};
 
 void pic() {
     husky::io::HDFSLineInputFormat infmt;
@@ -104,73 +141,209 @@ void pic() {
 
     int dimension = std::stoi(husky::Context::get_param("dimension"));
 
-    husky::base::log_msg( "input " + husky::Context::get_param("input"));
-    husky::base::log_msg( "dim " + std::to_string(dimension));
-
     // 1. Create and globalize ndpoint objects
     husky::ObjList<NDpoint> ndpoint_list;
     auto parse_ndpoint = [&ndpoint_list](boost::string_ref& chunk) {
-        husky::base::log_msg("pt1");
         if (chunk.size() == 0)
             return;
         boost::char_separator<char> sep(" \t");
         boost::tokenizer<boost::char_separator<char>> tok(chunk, sep);
         boost::tokenizer<boost::char_separator<char>>::iterator it = tok.begin();
         int id = stoi(*it++);
-        it++;
         std::vector<float> coords;
-        husky::base::log_msg("pt2");
         while (it != tok.end()) {
             coords.push_back(stod(*it++));
         }
-        husky::base::log_msg( "data " + std::to_string(id) + " " +std::to_string(coords[0]) + " " + std::to_string(coords[1]));
         ndpoint_list.add_object(NDpoint(id, coords));
     };
-    husky::base::log_msg( "part1a ok ");
     load(infmt, parse_ndpoint);
-    husky::base::log_msg( "part1b ok ");
     globalize(ndpoint_list);
+    husky::base::log_msg( "ndpoint_list size " + std::to_string( ndpoint_list.get_size()));
+
     husky::base::log_msg( "part1 ok ");
     
     // 2. calculate the variance used in similarity function
     husky::ObjList<DimStat> dimstat_list;
+    globalize(dimstat_list);
+
+    husky::lib::Aggregator<int> sumAgg;
+    auto& ac = husky::lib::AggregatorFactory::get_channel();
+
     auto& meanCh =
         husky::ChannelFactory::create_push_combined_channel<float, husky::SumCombiner<float>>(ndpoint_list, dimstat_list);
     auto& varCh =
         husky::ChannelFactory::create_push_combined_channel<float, husky::SumCombiner<float>>(ndpoint_list, dimstat_list);
-    list_execute(ndpoint_list, [&meanCh, &varCh](NDpoint& p) {
+    list_execute(ndpoint_list, {}, {&ac, &meanCh, &varCh}, [&sumAgg, &meanCh, &varCh](NDpoint& p) {
         int idx=0;
         for (auto& aVal : p.coords) {
             meanCh.push(      aVal, idx);
             varCh .push( aVal*aVal, idx);
             idx++;
         }
+        sumAgg.update(1);
     });
 
-    size_t totDataPoints = ndpoint_list.get_size();
-    husky::base::log_msg( "totPts" + totDataPoints);
-
-    list_execute(dimstat_list, [&meanCh, &varCh, &totDataPoints](DimStat& d) {
-        d.mean = meanCh.get(d)/totDataPoints;
-        d.var  = sqrt(varCh.get(d)/totDataPoints - d.mean*d.mean); //Var(x) = sqrt(<x^2> - <x><x>)
-        husky::base::log_msg( "stat " + std::to_string(d.id()) + "  " + std::to_string(d.mean) + " " + std::to_string(d.var));
+    list_execute(dimstat_list, [&sumAgg, &meanCh, &varCh](DimStat& d) {
+        int count = sumAgg.get_value(); 
+        d.mean = meanCh.get(d)/count;
+        d.var  = varCh.get(d)/count - d.mean*d.mean; //Var(x) = <x^2> - <x><x>
+        husky::base::log_msg( "stat " + std::to_string(d.id()) + "  " + std::to_string(count) + " " + std::to_string(d.mean) + " " + std::to_string(d.var));
     });
 
     husky::base::log_msg( "part2 ok ");
 
-    //FIXME:: how to decide point pairing up to minimize traffic?
-    //        should I store a local copy of dimstat_list?
+    // 3. calculate the affinity matrix
+    husky::ObjList<MatElem> affMatElem_list;
+    globalize(affMatElem_list);
     auto& pairCh =
-        husky::ChannelFactory::create_push_channel<NDpoint>(ndpoint_list, ndpoint_list);
+        husky::ChannelFactory::create_push_channel<NDpoint>(ndpoint_list, affMatElem_list);
 
+    //FIXME:: seems stupid to create a Channel just to make a list accessable by all worker?
+    auto& dimstatBCh = husky::ChannelFactory::create_broadcast_channel<int,DimStat>(dimstat_list);
+    list_execute(dimstat_list, [&](DimStat& d) {
+        dimstatBCh.broadcast( d.id(), d);
+    });
+
+    ////Why this doesn't work? I get vec of size 0 even dimstat_list is globalized
+    //std::vector<DimStat> local_dimstat_list = dimstat_list.get_data(); 
+    //husky::base::log_msg( "local dim stat size " + std::to_string(local_dimstat_list.size()));
+    //assert(local_dimstat_list.size() == dimension);
+    
+    size_t totDataPoints = sumAgg.get_value();
+
+    //FIXME:: how to decide point pairing up to minimize traffic? Will husky auto place affMatElem on worker with best data locality?
+    //        right now I push 2 data points to each matrix element
     list_execute(ndpoint_list, [&](NDpoint & p) {
-        //FIXME:: the i for loop assumed the input data has index 0 to totDataPoints
-        for (int i = 0; i < totDataPoints; ++i) {
-            if (i == p.id()) { continue;} //don't pair up with oneself
-            if      ((p.id()%2)==0 && (i%2)==1 ){ pairCh.push(p, i);}  //10 will push itself to 0 2 4 6 8
-            else if ((p.id()%2)==1 && (i%2)==0 ){ pairCh.push(p, i);}  //10 will receive from 1 3 5 7 9
+        for (uint i = 0; i < p.id(); ++i) {
+            pairCh.push(p, i*totDataPoints + p.id() );
+        }
+        for (uint i = p.id()+1; i < totDataPoints; ++i) {
+            pairCh.push(p, p.id()*totDataPoints + i );
         }
     });
+
+    husky::base::log_msg( "affMat size " + std::to_string(affMatElem_list.get_size()));
+
+    husky::ObjList<DimStat> rowstat_list;
+    auto& rowsumCh =
+        husky::ChannelFactory::create_push_combined_channel<float, husky::SumCombiner<float>>(affMatElem_list, rowstat_list);
+
+    list_execute(affMatElem_list, [&](MatElem & e){
+        auto pts = pairCh.get(e);
+        float nSigmaSq = 0;
+
+        //if(e.id()==10011){
+        //    husky::base::log_msg( "========" );
+        //    for (auto aVal : pts){ husky::base::log_msg( "getval " + std::to_string(aVal.coords[0]));}
+        //    husky::base::log_msg( "========" + std::to_string(local_dimstat_list[0]->var) );
+        //}
+
+        for (uint i =0; i<dimension;i++){ nSigmaSq += pow( pts[0].coords[i] - pts[1].coords[i], 2)/ (2.*dimstatBCh.get(i).var); }
+        e.val = exp( -nSigmaSq);
+        int row = e.id()/totDataPoints;
+        int col = e.id()%totDataPoints;
+        rowsumCh.push( e.val, row);
+        rowsumCh.push( e.val, col);
+        rowsumCh.push( e.val, -1 ); //hack, -1 is for calculating the volume (sum of all elements) of the affMat
+    });
+
+    //calculate then boardcast the rowsum. (is there a push_combine_boardcast channel API?)
+    auto& rowsumBCh = husky::ChannelFactory::create_broadcast_channel<int, float>(rowstat_list);
+    list_execute(rowstat_list, [&](DimStat & r){
+        rowsumBCh.broadcast( r.id(), rowsumCh.get(r) );
+    });
+
+    husky::base::log_msg( "part3 ok ");
+
+    // 4. repeat multiply the affinity matrix to the vector till convergence
+
+    //To row normalized the affMat we need to calculate D*A, where D is diagonal matrix with 1/rowsum at the diagonal
+    //We want Vn = (D*A) * ... * (D*A) * (D*A) * V0
+    //Instead of calculating D*A, we can just multiply D on the A*V0 vector
+    //ie. V1 = D*(A*V0)
+    //    V2 = D*(A*V1)...
+
+    float affMatVol = rowsumBCh.get(-1)*2.;
+
+    husky::ObjList<VElem> velem_list;
+    int chunkSize = totDataPoints/husky::Context::get_worker_info()->get_num_workers()+1;
+    int startPos  = chunkSize * husky::Context::get_global_tid();
+    int endPos    = std::min( int(totDataPoints) , chunkSize * (husky::Context::get_global_tid()+1));
+
+    //Init V0
+    for (uint i = startPos; i<endPos; i++){
+        VElem e(i);
+        e.setVal( rowsumBCh.get(i) / affMatVol );
+        velem_list.add_object( e );
+    }
+    globalize(velem_list);
+
+    husky::base::log_msg( "vec "
+                          + std::to_string(velem_list.get_size()) + " "
+                          + std::to_string(startPos) + " "
+                          + std::to_string(endPos) + " "
+                        );
+
+    //FIXME:: Instead of the whole object, should push only the val and id of VElem to the Mat
+    auto& vecToMatCh =
+        husky::ChannelFactory::create_push_channel<VElem>(velem_list, affMatElem_list);
+    auto& matToVecCh =
+        husky::ChannelFactory::create_push_combined_channel<float, husky::SumCombiner<float>>(affMatElem_list, velem_list);
+
+    husky::lib::Aggregator<float> maxFloatAgg(0., [](float& a, const float& b){ if (b>a) a=b; } );
+
+    int   maxIter = std::stoi(husky::Context::get_param("maxIter"));
+    float epsilon = std::stod(husky::Context::get_param("stopThres"));
+
+    if (maxIter<0) maxIter=10;
+    if (epsilon<0) epsilon=1e-5/totDataPoints;
+
+    for (uint iter=0; iter<maxIter; ++iter){
+
+        list_execute(velem_list, [&](VElem & v){
+            for (uint i = 0       ; i < v.id()       ; ++i) { vecToMatCh.push( v, i*totDataPoints + v.id() ); }
+            for (uint i = v.id()+1; i < totDataPoints; ++i) { vecToMatCh.push( v, v.id()*totDataPoints + i ); }
+        });
+
+        list_execute(affMatElem_list, [&](MatElem & e){
+            int row = e.id()/totDataPoints;
+            int col = e.id()%totDataPoints;
+            auto& vlist = vecToMatCh.get(e);
+            if (vlist.size()!=2) husky::base::log_msg( "What? " + std::to_string(vlist.size()) );
+            for (auto& aVElem : vlist){
+                if      (aVElem.id()==row) matToVecCh.push( e.val*aVElem.val, col );
+                else if (aVElem.id()==col) matToVecCh.push( e.val*aVElem.val, row );
+                else husky::base::log_msg( "What2? " + std::to_string(aVElem.id()) + " " + std::to_string(e.id() ) );
+            }
+        });
+        
+        list_execute(velem_list,{&matToVecCh},{&ac}, [&](VElem & v){
+            v.setVal( matToVecCh.get(v) / rowsumBCh.get( v.id() ) );
+            maxFloatAgg.update( v.getAcc() );
+        });
+        
+        if (husky::Context::get_global_tid()==0){
+            husky::base::log_msg(   "Iter "   + std::to_string(iter) + " "
+                                  + "MaxAcc " + std::to_string(maxFloatAgg.get_value()*totDataPoints ));
+        }
+
+        if (maxFloatAgg.get_value()<epsilon) break;
+        maxFloatAgg.to_reset_each_iter();
+        //maxFloatAgg.to_keep_aggregate();
+
+
+    }//end iter loop
+
+    //lazily output to screen
+    list_execute(velem_list, [&](VElem & v){
+        char s[100];
+        sprintf(s, "%e", v.val);
+        husky::base::log_msg( "result v "
+                              + std::to_string(v.id() )   + " "
+                              + s  + " "
+                            );
+    });
+
 
 }
 
@@ -180,6 +353,8 @@ int main(int argc, char** argv) {
     args.push_back("hdfs_namenode_port");
     args.push_back("input");
     args.push_back("dimension");
+    args.push_back("maxIter");
+    args.push_back("stopThres");
     if (husky::init_with_args(argc, argv, args)) {
         husky::run_job(pic);
         return 0;

--- a/examples/pic.cpp
+++ b/examples/pic.cpp
@@ -187,14 +187,27 @@ void pic() {
 }
 
 int main(int argc, char** argv) {
+    // Input:
+    // The affinity matrix output by affinity.cpp i.e.
+    // A txt with each line containing 1 row of the affinity matrix as
+    // rowID rowElem1 rowElem2 rowElem3 ...rowElemN
+    //
+    // Output:
+    // A txt with the each line as
+    // pointID classificationVal
+    // eg.
+    // 0 0.001
+    // 1 0.0009
+    // 2 0.0009
+    // ...
     std::vector<std::string> args;
     args.push_back("hdfs_namenode");
     args.push_back("hdfs_namenode_port");
-    args.push_back("input");
-    args.push_back("outDir");
-    args.push_back("maxIter");      // <=0 implies 10
-    args.push_back("stopThres");    // <=0 implies auto
-    args.push_back("outPerNIter");  // <=0 implies turn off
+    args.push_back("input");        // path to input file eg. hdfs:///user/ylchan/AffMat_T2/merge
+    args.push_back("outDir");       // output dir in hdfs eg. /user/ylchan/testPIC/
+    args.push_back("maxIter");      // max no. of power iteration to do (setting <=0 implies 10)
+    args.push_back("stopThres");    // stopping threshold (setting <=0 implies auto)
+    args.push_back("outPerNIter");  // saving intermediate result every N iteration (<=0 implies turn off)
     if (husky::init_with_args(argc, argv, args)) {
         husky::run_job(pic);
         return 0;

--- a/examples/pic.cpp
+++ b/examples/pic.cpp
@@ -1,0 +1,188 @@
+// Copyright 2016 Husky Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <random>
+#include <string>
+#include <vector>
+
+#include "boost/tokenizer.hpp"
+
+#include "core/engine.hpp"
+#include "io/input/hdfs_line_inputformat.hpp"
+
+void normalize(std::vector<double> &f, double rowsum) {
+        for (auto & x : f) {
+                    x /= rowsum;
+                        }
+}
+
+double magnitude(std::vector<double> &a) {
+        double sum = 0.0;
+            for (auto & x : a) {
+                        sum += pow(x, 2);
+                            }
+                return sqrt(sum);
+}
+
+double difference(std::vector<double> &a, std::vector<double> &b) {
+        double sum = 0.0;
+            int size = a.size();
+                for (int i = 0; i < size; ++i) {
+                            sum += pow(a[i] - b[i], 2);
+                                }
+                    return sum;
+}
+
+double similarity(std::vector<double> &a, std::vector<double> &b, double var) {
+        double S_ab = exp(-(difference(a, b))/(2 * var));
+            return S_ab;
+}
+
+class NDpoint {
+   public:
+    using KeyT = int;
+
+    NDpoint() {}
+    explicit NDpoint(const KeyT& w) : pointId(w) {}
+    NDpoint(const KeyT& pId, std::vector<float> coords) {
+        this->pointId = pId;
+        this->coords  = std::move(coords);
+    }
+    virtual const KeyT& id() const { return pointId; }
+
+    // Serialization and deserialization
+    friend husky::BinStream& operator<<(husky::BinStream& stream, NDpoint u) {
+        stream << u.pointId<< u.coords;
+        return stream;
+    }
+    friend husky::BinStream& operator>>(husky::BinStream& stream, NDpoint& u) {
+        stream >> u.pointId >> u.coords;
+        return stream;
+    }
+
+    int pointId;
+    std::vector<float> coords;
+};
+
+class DimStat {
+   public:
+    using KeyT = int;
+
+    DimStat() {}
+    explicit DimStat(const KeyT& w) : dimId(w) {}
+    virtual const KeyT& id() const { return dimId; }
+
+    int dimId;
+    float mean;
+    float var;
+};
+
+class PIObject {
+   public:
+    typedef int KeyT;
+    int key;
+
+    explicit PIObject(KeyT key) { this->key = key; }
+
+    const int& id() const { return key; }
+};
+
+void pic() {
+    husky::io::HDFSLineInputFormat infmt;
+    infmt.set_input(husky::Context::get_param("input"));
+
+    int dimension = std::stoi(husky::Context::get_param("dimension"));
+
+    husky::base::log_msg( "input " + husky::Context::get_param("input"));
+    husky::base::log_msg( "dim " + std::to_string(dimension));
+
+    // 1. Create and globalize ndpoint objects
+    husky::ObjList<NDpoint> ndpoint_list;
+    auto parse_ndpoint = [&ndpoint_list](boost::string_ref& chunk) {
+        husky::base::log_msg("pt1");
+        if (chunk.size() == 0)
+            return;
+        boost::char_separator<char> sep(" \t");
+        boost::tokenizer<boost::char_separator<char>> tok(chunk, sep);
+        boost::tokenizer<boost::char_separator<char>>::iterator it = tok.begin();
+        int id = stoi(*it++);
+        it++;
+        std::vector<float> coords;
+        husky::base::log_msg("pt2");
+        while (it != tok.end()) {
+            coords.push_back(stod(*it++));
+        }
+        husky::base::log_msg( "data " + std::to_string(id) + " " +std::to_string(coords[0]) + " " + std::to_string(coords[1]));
+        ndpoint_list.add_object(NDpoint(id, coords));
+    };
+    husky::base::log_msg( "part1a ok ");
+    load(infmt, parse_ndpoint);
+    husky::base::log_msg( "part1b ok ");
+    globalize(ndpoint_list);
+    husky::base::log_msg( "part1 ok ");
+    
+    // 2. calculate the variance used in similarity function
+    husky::ObjList<DimStat> dimstat_list;
+    auto& meanCh =
+        husky::ChannelFactory::create_push_combined_channel<float, husky::SumCombiner<float>>(ndpoint_list, dimstat_list);
+    auto& varCh =
+        husky::ChannelFactory::create_push_combined_channel<float, husky::SumCombiner<float>>(ndpoint_list, dimstat_list);
+    list_execute(ndpoint_list, [&meanCh, &varCh](NDpoint& p) {
+        int idx=0;
+        for (auto& aVal : p.coords) {
+            meanCh.push(      aVal, idx);
+            varCh .push( aVal*aVal, idx);
+            idx++;
+        }
+    });
+
+    size_t totDataPoints = ndpoint_list.get_size();
+    husky::base::log_msg( "totPts" + totDataPoints);
+
+    list_execute(dimstat_list, [&meanCh, &varCh, &totDataPoints](DimStat& d) {
+        d.mean = meanCh.get(d)/totDataPoints;
+        d.var  = sqrt(varCh.get(d)/totDataPoints - d.mean*d.mean); //Var(x) = sqrt(<x^2> - <x><x>)
+        husky::base::log_msg( "stat " + std::to_string(d.id()) + "  " + std::to_string(d.mean) + " " + std::to_string(d.var));
+    });
+
+    husky::base::log_msg( "part2 ok ");
+
+    //FIXME:: how to decide point pairing up to minimize traffic?
+    //        should I store a local copy of dimstat_list?
+    auto& pairCh =
+        husky::ChannelFactory::create_push_channel<NDpoint>(ndpoint_list, ndpoint_list);
+
+    list_execute(ndpoint_list, [&](NDpoint & p) {
+        //FIXME:: the i for loop assumed the input data has index 0 to totDataPoints
+        for (int i = 0; i < totDataPoints; ++i) {
+            if (i == p.id()) { continue;} //don't pair up with oneself
+            if      ((p.id()%2)==0 && (i%2)==1 ){ pairCh.push(p, i);}  //10 will push itself to 0 2 4 6 8
+            else if ((p.id()%2)==1 && (i%2)==0 ){ pairCh.push(p, i);}  //10 will receive from 1 3 5 7 9
+        }
+    });
+
+}
+
+int main(int argc, char** argv) {
+    std::vector<std::string> args;
+    args.push_back("hdfs_namenode");
+    args.push_back("hdfs_namenode_port");
+    args.push_back("input");
+    args.push_back("dimension");
+    if (husky::init_with_args(argc, argv, args)) {
+        husky::run_job(pic);
+        return 0;
+    }
+    return 1;
+}

--- a/examples/pic.cpp
+++ b/examples/pic.cpp
@@ -19,332 +19,171 @@
 #include "boost/tokenizer.hpp"
 
 #include "core/engine.hpp"
-#include "io/input/hdfs_line_inputformat.hpp"
+#include "io/hdfs_manager.hpp"
+#include "io/input/line_inputformat.hpp"
 #include "lib/aggregator_factory.hpp"
 
+typedef std::vector<float> edgeWvec;
 
-class NDpoint {
-   //N-dimension point modelling the input data
+class Node {
+    // A node storing node value and connected edges (node value forms the classification vector)
    public:
     using KeyT = int;
 
-    NDpoint() {}
-    explicit NDpoint(const KeyT& w) : pointId(w) {}
-    NDpoint(const KeyT& pId, std::vector<float> coords) {
-        this->pointId = pId;
-        this->coords  = std::move(coords);
+    Node() {}
+    explicit Node(const KeyT& p) : pos(p), edgeW(), val(0.), valp(0.), valpp(0.) {}
+    Node(const KeyT& p, edgeWvec edgeW, float edgeWsum) {
+        this->pos = p;
+        this->edgeWsum = edgeWsum;
+        this->edgeW = std::move(edgeW);
+        this->val = 0.;
+        this->valp = 0.;
+        this->valpp = 0.;
     }
-    virtual const KeyT& id() const { return pointId; }
-
-    // Serialization and deserialization
-    friend husky::BinStream& operator<<(husky::BinStream& stream, NDpoint u) {
-        stream << u.pointId<< u.coords;
-        return stream;
-    }
-    friend husky::BinStream& operator>>(husky::BinStream& stream, NDpoint& u) {
-        stream >> u.pointId >> u.coords;
-        return stream;
-    }
-
-    int pointId;
-    std::vector<float> coords;
-};
-
-class MatElem {
-   //Matrix elemet for the affinity matrix
-   public:
-    //using KeyT = std::pair<uint, uint>; // std::hash don't like std::pair
-    using KeyT = uint;
-
-    MatElem() {}
-    explicit MatElem(const KeyT& p) : pos(p) {}
     virtual const KeyT& id() const { return pos; }
 
     // Serialization and deserialization
-    friend husky::BinStream& operator<<(husky::BinStream& stream, MatElem u) {
-        stream << u.pos << u.val;
+    friend husky::BinStream& operator<<(husky::BinStream& stream, Node u) {
+        stream << u.pos << u.edgeW << u.val << u.valp << u.valpp << u.valtmp;
         return stream;
     }
-    friend husky::BinStream& operator>>(husky::BinStream& stream, MatElem& u) {
-        stream >> u.pos >> u.val;
+    friend husky::BinStream& operator>>(husky::BinStream& stream, Node& u) {
+        stream >> u.pos >> u.edgeW >> u.val >> u.valp >> u.valpp >> u.valtmp;
         return stream;
     }
 
     KeyT pos;
+
+    edgeWvec edgeW;
+    float edgeWsum;
+
     float val;
-};
+    float valp;    // val at previous iteration
+    float valpp;   // val at previousX2 iteration
+    float valtmp;  // val before normalize
 
-class VElem {
-   //Element for the classification vector V
-   public:
-    //using KeyT = std::pair<uint, uint>; // std::hash don't like std::pair
-    using KeyT = int;
-
-    VElem() {}
-    explicit VElem(const KeyT& p) : pos(p), val(0.), valp(0.), valpp(0.) {}
-    virtual const KeyT& id() const { return pos; }
-
-    // Serialization and deserialization
-    friend husky::BinStream& operator<<(husky::BinStream& stream, VElem u) {
-        stream << u.pos << u.val << u.valp << u.valpp;
-        return stream;
-    }
-    friend husky::BinStream& operator>>(husky::BinStream& stream, VElem& u) {
-        stream >> u.pos >> u.val >> u.valp >> u.valpp;
-        return stream;
-    }
-
-    KeyT pos;
-    float val;
-    float valp;  //val at previous iteration
-    float valpp; //val at previousX2 iteration
-
-    void setVal(float newval){
+    void setVal(float newval) {
         valpp = valp;
-        valp  = val;
-        val   = newval;
+        valp = val;
+        val = newval;
     }
 
-    float getAcc(){
-        return fabs(fabs(val-valp) - fabs(valp-valpp));
-    }
+    // Accelation of node value change, for deciding when to stop iter
+    float getAcc() { return fabs(fabs(val - valp) - fabs(valp - valpp)); }
 };
-
-class DimStat {
-   //Dimension statistics
-   public:
-    using KeyT = int;
-
-    DimStat() {}
-    explicit DimStat(const KeyT& w) : dimId(w) {}
-    virtual const KeyT& id() const { return dimId; }
-
-    // Serialization and deserialization
-    friend husky::BinStream& operator<<(husky::BinStream& stream, DimStat u) {
-        stream << u.dimId << u.mean << u.var;
-        return stream;
-    }
-    friend husky::BinStream& operator>>(husky::BinStream& stream, DimStat& u) {
-        stream >> u.dimId >> u.mean >> u.var;
-        return stream;
-    }
-
-    int dimId;
-    float mean;
-    float var;
-};
-
 
 void pic() {
-    husky::io::HDFSLineInputFormat infmt;
+    husky::io::LineInputFormat infmt;
     infmt.set_input(husky::Context::get_param("input"));
 
-    int dimension = std::stoi(husky::Context::get_param("dimension"));
+    husky::lib::Aggregator<int> dataCountAgg;    // total no. of rows in input affinity matrix
+    husky::lib::Aggregator<float> affMatVolAgg;  // sum of elements' val in affinity matrix
+    auto& ac = husky::lib::AggregatorFactory::get_channel();
 
-    // 1. Create and globalize ndpoint objects
-    husky::ObjList<NDpoint> ndpoint_list;
-    auto parse_ndpoint = [&ndpoint_list](boost::string_ref& chunk) {
+    // 1. Create and globalize node objects
+    auto& node_list = husky::ObjListFactory::create_objlist<Node>();
+    auto parse_affMatRow = [&](boost::string_ref& chunk) {
         if (chunk.size() == 0)
             return;
         boost::char_separator<char> sep(" \t");
         boost::tokenizer<boost::char_separator<char>> tok(chunk, sep);
         boost::tokenizer<boost::char_separator<char>>::iterator it = tok.begin();
         int id = stoi(*it++);
-        std::vector<float> coords;
+        float edgeWsum = 0.;
+        edgeWvec edgeW;
         while (it != tok.end()) {
-            coords.push_back(stod(*it++));
+            float tmp = stod(*it++);
+            edgeW.push_back(tmp);
+            edgeWsum += tmp;
         }
-        ndpoint_list.add_object(NDpoint(id, coords));
+        edgeW.shrink_to_fit();
+
+        dataCountAgg.update(1);
+        affMatVolAgg.update(edgeWsum);
+        node_list.add_object(Node(id, edgeW, edgeWsum));
     };
-    load(infmt, parse_ndpoint);
-    globalize(ndpoint_list);
-    husky::base::log_msg( "ndpoint_list size " + std::to_string( ndpoint_list.get_size()));
+    load(infmt, {&ac}, parse_affMatRow);
+    husky::globalize(node_list);
 
-    husky::base::log_msg( "part1 ok ");
-    
-    // 2. calculate the variance used in similarity function
-    husky::ObjList<DimStat> dimstat_list;
-    globalize(dimstat_list);
+    int totDataPoints = dataCountAgg.get_value();
+    husky::base::log_msg("node_list size " + std::to_string(totDataPoints));
 
-    husky::lib::Aggregator<int> sumAgg;
-    auto& ac = husky::lib::AggregatorFactory::get_channel();
-
-    auto& meanCh =
-        husky::ChannelFactory::create_push_combined_channel<float, husky::SumCombiner<float>>(ndpoint_list, dimstat_list);
-    auto& varCh =
-        husky::ChannelFactory::create_push_combined_channel<float, husky::SumCombiner<float>>(ndpoint_list, dimstat_list);
-    list_execute(ndpoint_list, {}, {&ac, &meanCh, &varCh}, [&sumAgg, &meanCh, &varCh](NDpoint& p) {
-        int idx=0;
-        for (auto& aVal : p.coords) {
-            meanCh.push(      aVal, idx);
-            varCh .push( aVal*aVal, idx);
-            idx++;
-        }
-        sumAgg.update(1);
+    // 2. Init guess as suggested by paper
+    list_execute(node_list, [&](Node& n) {
+        assert(n.edgeW.size() == totDataPoints);
+        n.setVal(n.edgeWsum / affMatVolAgg.get_value());
     });
 
-    list_execute(dimstat_list, [&sumAgg, &meanCh, &varCh](DimStat& d) {
-        int count = sumAgg.get_value(); 
-        d.mean = meanCh.get(d)/count;
-        d.var  = varCh.get(d)/count - d.mean*d.mean; //Var(x) = <x^2> - <x><x>
-        husky::base::log_msg( "stat " + std::to_string(d.id()) + "  " + std::to_string(count) + " " + std::to_string(d.mean) + " " + std::to_string(d.var));
+    // 3. repeat multiply the affinity matrix to the vector till convergence
+    // The Mat multiplication is same as each node doing a weighted average of its connected neighbors' value
+
+    husky::lib::Aggregator<float> maxFloatAgg(0., [](float& a, const float& b) {
+        if (b > a)
+            a = b;
     });
+    husky::lib::Aggregator<float> normFacAgg(0.);
+    auto& nodeTonodeCh =
+        husky::ChannelFactory::create_push_combined_channel<float, husky::SumCombiner<float>>(node_list, node_list);
 
-    husky::base::log_msg( "part2 ok ");
-
-    // 3. calculate the affinity matrix
-    husky::ObjList<MatElem> affMatElem_list;
-    globalize(affMatElem_list);
-    auto& pairCh =
-        husky::ChannelFactory::create_push_channel<NDpoint>(ndpoint_list, affMatElem_list);
-
-    //FIXME:: seems stupid to create a Channel just to make a list accessable by all worker?
-    auto& dimstatBCh = husky::ChannelFactory::create_broadcast_channel<int,DimStat>(dimstat_list);
-    list_execute(dimstat_list, [&](DimStat& d) {
-        dimstatBCh.broadcast( d.id(), d);
-    });
-
-    ////Why this doesn't work? I get vec of size 0 even dimstat_list is globalized
-    //std::vector<DimStat> local_dimstat_list = dimstat_list.get_data(); 
-    //husky::base::log_msg( "local dim stat size " + std::to_string(local_dimstat_list.size()));
-    //assert(local_dimstat_list.size() == dimension);
-    
-    size_t totDataPoints = sumAgg.get_value();
-
-    //FIXME:: how to decide point pairing up to minimize traffic? Will husky auto place affMatElem on worker with best data locality?
-    //        right now I push 2 data points to each matrix element
-    list_execute(ndpoint_list, [&](NDpoint & p) {
-        for (uint i = 0; i < p.id(); ++i) {
-            pairCh.push(p, i*totDataPoints + p.id() );
-        }
-        for (uint i = p.id()+1; i < totDataPoints; ++i) {
-            pairCh.push(p, p.id()*totDataPoints + i );
-        }
-    });
-
-    husky::base::log_msg( "affMat size " + std::to_string(affMatElem_list.get_size()));
-
-    husky::ObjList<DimStat> rowstat_list;
-    auto& rowsumCh =
-        husky::ChannelFactory::create_push_combined_channel<float, husky::SumCombiner<float>>(affMatElem_list, rowstat_list);
-
-    list_execute(affMatElem_list, [&](MatElem & e){
-        auto pts = pairCh.get(e);
-        float nSigmaSq = 0;
-
-        //if(e.id()==10011){
-        //    husky::base::log_msg( "========" );
-        //    for (auto aVal : pts){ husky::base::log_msg( "getval " + std::to_string(aVal.coords[0]));}
-        //    husky::base::log_msg( "========" + std::to_string(local_dimstat_list[0]->var) );
-        //}
-
-        for (uint i =0; i<dimension;i++){ nSigmaSq += pow( pts[0].coords[i] - pts[1].coords[i], 2)/ (2.*dimstatBCh.get(i).var); }
-        e.val = exp( -nSigmaSq);
-        int row = e.id()/totDataPoints;
-        int col = e.id()%totDataPoints;
-        rowsumCh.push( e.val, row);
-        rowsumCh.push( e.val, col);
-        rowsumCh.push( e.val, -1 ); //hack, -1 is for calculating the volume (sum of all elements) of the affMat
-    });
-
-    //calculate then boardcast the rowsum. (is there a push_combine_boardcast channel API?)
-    auto& rowsumBCh = husky::ChannelFactory::create_broadcast_channel<int, float>(rowstat_list);
-    list_execute(rowstat_list, [&](DimStat & r){
-        rowsumBCh.broadcast( r.id(), rowsumCh.get(r) );
-    });
-
-    husky::base::log_msg( "part3 ok ");
-
-    // 4. repeat multiply the affinity matrix to the vector till convergence
-
-    //To row normalized the affMat we need to calculate D*A, where D is diagonal matrix with 1/rowsum at the diagonal
-    //We want Vn = (D*A) * ... * (D*A) * (D*A) * V0
-    //Instead of calculating D*A, we can just multiply D on the A*V0 vector
-    //ie. V1 = D*(A*V0)
-    //    V2 = D*(A*V1)...
-
-    float affMatVol = rowsumBCh.get(-1)*2.;
-
-    husky::ObjList<VElem> velem_list;
-    int chunkSize = totDataPoints/husky::Context::get_worker_info()->get_num_workers()+1;
-    int startPos  = chunkSize * husky::Context::get_global_tid();
-    int endPos    = std::min( int(totDataPoints) , chunkSize * (husky::Context::get_global_tid()+1));
-
-    //Init V0
-    for (uint i = startPos; i<endPos; i++){
-        VElem e(i);
-        e.setVal( rowsumBCh.get(i) / affMatVol );
-        velem_list.add_object( e );
-    }
-    globalize(velem_list);
-
-    husky::base::log_msg( "vec "
-                          + std::to_string(velem_list.get_size()) + " "
-                          + std::to_string(startPos) + " "
-                          + std::to_string(endPos) + " "
-                        );
-
-    //FIXME:: Instead of the whole object, should push only the val and id of VElem to the Mat
-    auto& vecToMatCh =
-        husky::ChannelFactory::create_push_channel<VElem>(velem_list, affMatElem_list);
-    auto& matToVecCh =
-        husky::ChannelFactory::create_push_combined_channel<float, husky::SumCombiner<float>>(affMatElem_list, velem_list);
-
-    husky::lib::Aggregator<float> maxFloatAgg(0., [](float& a, const float& b){ if (b>a) a=b; } );
-
-    int   maxIter = std::stoi(husky::Context::get_param("maxIter"));
+    int maxIter = std::stoi(husky::Context::get_param("maxIter"));
     float epsilon = std::stod(husky::Context::get_param("stopThres"));
 
-    if (maxIter<0) maxIter=10;
-    if (epsilon<0) epsilon=1e-5/totDataPoints;
+    int outPerNIter = std::stoi(husky::Context::get_param("outPerNIter"));
 
-    for (uint iter=0; iter<maxIter; ++iter){
+    if (maxIter < 0)
+        maxIter = 10;
+    if (epsilon < 0)
+        epsilon = 1e-5 / totDataPoints;
 
-        list_execute(velem_list, [&](VElem & v){
-            for (uint i = 0       ; i < v.id()       ; ++i) { vecToMatCh.push( v, i*totDataPoints + v.id() ); }
-            for (uint i = v.id()+1; i < totDataPoints; ++i) { vecToMatCh.push( v, v.id()*totDataPoints + i ); }
-        });
-
-        list_execute(affMatElem_list, [&](MatElem & e){
-            int row = e.id()/totDataPoints;
-            int col = e.id()%totDataPoints;
-            auto& vlist = vecToMatCh.get(e);
-            if (vlist.size()!=2) husky::base::log_msg( "What? " + std::to_string(vlist.size()) );
-            for (auto& aVElem : vlist){
-                if      (aVElem.id()==row) matToVecCh.push( e.val*aVElem.val, col );
-                else if (aVElem.id()==col) matToVecCh.push( e.val*aVElem.val, row );
-                else husky::base::log_msg( "What2? " + std::to_string(aVElem.id()) + " " + std::to_string(e.id() ) );
+    for (uint iter = 0; iter < maxIter; ++iter) {
+        list_execute(node_list, [&](Node& n) {
+            // here we assuemed the edge is bidirectional with same weight (a.k.a Affinity mat is symmetric)
+            for (uint i = 0; i < n.id(); ++i) {
+                nodeTonodeCh.push(n.edgeW[i] * n.val, i);
+            }
+            for (uint i = n.id() + 1; i < totDataPoints; ++i) {
+                nodeTonodeCh.push(n.edgeW[i] * n.val, i);
             }
         });
-        
-        list_execute(velem_list,{&matToVecCh},{&ac}, [&](VElem & v){
-            v.setVal( matToVecCh.get(v) / rowsumBCh.get( v.id() ) );
-            maxFloatAgg.update( v.getAcc() );
+
+        list_execute(node_list, {&nodeTonodeCh}, {&ac}, [&](Node& n) {
+            n.valtmp = n.edgeWsum > 0 ? nodeTonodeCh.get(n) / n.edgeWsum : 0.0;
+            normFacAgg.update(n.valtmp);
         });
-        
-        if (husky::Context::get_global_tid()==0){
-            husky::base::log_msg(   "Iter "   + std::to_string(iter) + " "
-                                  + "MaxAcc " + std::to_string(maxFloatAgg.get_value()*totDataPoints ));
+
+        list_execute(node_list, {}, {&ac}, [&](Node& n) {
+            n.setVal(n.valtmp / normFacAgg.get_value());
+            maxFloatAgg.update(n.getAcc());
+            if (outPerNIter > 0 && iter % outPerNIter == 0) {
+                std::ostringstream oss;
+                oss.precision(17);
+                oss << n.id() << " " << n.val << "\n";
+                husky::io::HDFS::Write("master", "9000", oss.str(),
+                                       husky::Context::get_param("outDir") + "/iter" + std::to_string(iter),
+                                       husky::Context::get_global_tid());
+            }
+        });
+
+        if (husky::Context::get_global_tid() == 0) {
+            husky::base::log_msg("Iter " + std::to_string(iter) + " " + "MaxAcc " +
+                                 std::to_string(maxFloatAgg.get_value()) + " " + "log10(MaxAcc) " +
+                                 std::to_string(log10(maxFloatAgg.get_value())));
         }
 
-        if (maxFloatAgg.get_value()<epsilon) break;
+        if (maxFloatAgg.get_value() < epsilon)
+            break;
         maxFloatAgg.to_reset_each_iter();
-        //maxFloatAgg.to_keep_aggregate();
+        normFacAgg.to_reset_each_iter();
+    }  // end iter loop
 
-
-    }//end iter loop
-
-    //lazily output to screen
-    list_execute(velem_list, [&](VElem & v){
-        char s[100];
-        sprintf(s, "%e", v.val);
-        husky::base::log_msg( "result v "
-                              + std::to_string(v.id() )   + " "
-                              + s  + " "
-                            );
+    // 4. output
+    list_execute(node_list, [&](Node& n) {
+        std::ostringstream oss;
+        oss.precision(17);
+        oss << n.id() << " " << n.val << "\n";
+        husky::io::HDFS::Write("master", "9000", oss.str(), husky::Context::get_param("outDir") + "/fin",
+                               husky::Context::get_global_tid());
     });
-
-
 }
 
 int main(int argc, char** argv) {
@@ -352,9 +191,10 @@ int main(int argc, char** argv) {
     args.push_back("hdfs_namenode");
     args.push_back("hdfs_namenode_port");
     args.push_back("input");
-    args.push_back("dimension");
-    args.push_back("maxIter");
-    args.push_back("stopThres");
+    args.push_back("outDir");
+    args.push_back("maxIter");      // <=0 implies 10
+    args.push_back("stopThres");    // <=0 implies auto
+    args.push_back("outPerNIter");  // <=0 implies turn off
     if (husky::init_with_args(argc, argv, args)) {
         husky::run_job(pic);
         return 0;

--- a/examples/pic.cpp
+++ b/examples/pic.cpp
@@ -44,11 +44,11 @@ class Node {
 
     // Serialization and deserialization
     friend husky::BinStream& operator<<(husky::BinStream& stream, Node u) {
-        stream << u.pos << u.edgeW << u.val << u.valp << u.valpp << u.valtmp;
+        stream << u.pos << u.edgeW << u.edgeWsum << u.val << u.valp << u.valpp << u.valtmp;
         return stream;
     }
     friend husky::BinStream& operator>>(husky::BinStream& stream, Node& u) {
-        stream >> u.pos >> u.edgeW >> u.val >> u.valp >> u.valpp >> u.valtmp;
+        stream >> u.pos >> u.edgeW >> u.edgeWsum >> u.val >> u.valp >> u.valpp >> u.valtmp;
         return stream;
     }
 
@@ -96,6 +96,7 @@ void pic() {
             edgeW.push_back(tmp);
             edgeWsum += tmp;
         }
+        edgeW[id] = 0.0;
         edgeW.shrink_to_fit();
 
         dataCountAgg.update(1);
@@ -138,10 +139,7 @@ void pic() {
     for (uint iter = 0; iter < maxIter; ++iter) {
         list_execute(node_list, [&](Node& n) {
             // here we assuemed the edge is bidirectional with same weight (a.k.a Affinity mat is symmetric)
-            for (uint i = 0; i < n.id(); ++i) {
-                nodeTonodeCh.push(n.edgeW[i] * n.val, i);
-            }
-            for (uint i = n.id() + 1; i < totDataPoints; ++i) {
+            for (uint i = 0; i < totDataPoints; ++i) {
                 nodeTonodeCh.push(n.edgeW[i] * n.val, i);
             }
         });

--- a/examples/pic.cpp
+++ b/examples/pic.cpp
@@ -205,8 +205,8 @@ int main(int argc, char** argv) {
     args.push_back("hdfs_namenode_port");
     args.push_back("input");        // path to input file eg. hdfs:///user/ylchan/AffMat_T2/merge
     args.push_back("outDir");       // output dir in hdfs eg. /user/ylchan/testPIC/
-    args.push_back("maxIter");      // max no. of power iteration to do (setting <=0 implies 10)
-    args.push_back("stopThres");    // stopping threshold (setting <=0 implies auto)
+    args.push_back("maxIter");      // max no. of power iteration to do (setting <0 implies 10)
+    args.push_back("stopThres");    // stopping threshold (setting <0 implies auto)
     args.push_back("outPerNIter");  // saving intermediate result every N iteration (<=0 implies turn off)
     if (husky::init_with_args(argc, argv, args)) {
         husky::run_job(pic);


### PR DESCRIPTION
1) I split affinity matrix calculation and PIC to two file
2) The old code in bitbucket use a constant initial vector, this makes convergence a must at 1st iteration. I changed to use the init vector as suggest by the PIC paper
3) lint.py and clang-format.py passed

I intent to have this PR replacing the old one ([Examples] Add PIC example)I made some time ago and let idle.
