### PR TITLE
[Lib][Aggregator] Fix a problem in initialization

### DIFF
--- a/lib/aggregator.cpp
+++ b/lib/aggregator.cpp
@@ -38,9 +38,12 @@ AggregatorInfo::~AggregatorInfo() {
 AggregatorFactoryBase* AggregatorFactoryBase::create_factory() {
     // use registered factory constructor to create a factory
     auto& ctor = get_factory_constructor();
+    static std::mutex mutex;
+    mutex.lock();
     if (ctor == nullptr) {
         ctor = []() { return new AggregatorFactory(); };
     }
+    mutex.unlock();
     return ctor();
 }
 


### PR DESCRIPTION
Sometimes the program crashes during the initialization of Aggregators. The reason is that the intialization process is not thread-safe. This fix uses a mutex to solve the problem.

P.S. I'll rebase after my last PR is merged.