### PR TITLE
[Base][SessionLocal] Fix session local unittest failure

### DIFF
--- a/base/session_local_unittest.cpp
+++ b/base/session_local_unittest.cpp
@@ -24,6 +24,7 @@ class TestSessionLocal : public testing::Test {
 TEST_F(TestSessionLocal, Register) {
     SessionLocal::get_initializers().clear();
     SessionLocal::get_finalizers().clear();
+    SessionLocal::get_thread_finalizers().clear();
     // Something that needs NOT to be initialized
     int session_no = 0;
 
@@ -67,6 +68,9 @@ TEST_F(TestSessionLocal, Register) {
 }
 
 TEST_F(TestSessionLocal, MultiSessions) {
+    SessionLocal::get_initializers().clear();
+    SessionLocal::get_finalizers().clear();
+    SessionLocal::get_thread_finalizers().clear();
     // Something that needs NOT to be initialized
     int session_no = 0;
 
@@ -132,6 +136,10 @@ TEST_F(TestSessionLocal, MultiSessions) {
 }
 
 TEST_F(TestSessionLocal, ThreadFinalizer) {
+    SessionLocal::get_initializers().clear();
+    SessionLocal::get_finalizers().clear();
+    SessionLocal::get_thread_finalizers().clear();
+
     bool* some_bool = nullptr;
     int* some_int = nullptr;
     EXPECT_EQ(SessionLocal::get_thread_finalizers().empty(), true);


### PR DESCRIPTION
This is to fix a small issue mentioned in #142. Thank TomNash!

To clear the initializer vector, finalizer vector and thread finalizer vector before any tests.