### PR TITLE
[Build] Better support for different platforms

### DIFF
--- a/core/combiner.cpp
+++ b/core/combiner.cpp
@@ -23,7 +23,7 @@ void sort_buffer_by_key(std::vector<int>& combine_buffer) {
     boost::sort::spreadsort::spreadsort(combine_buffer.begin(), combine_buffer.end());
 }
 
-#ifdef __linux__
+#ifdef _MSC_VER
 void sort_buffer_by_key_msg(std::vector<std::pair<int, int>>& combine_buffer) {
     auto get_char = [](int x, size_t offset) {
         const int bit_shift = 8 * (sizeof(int) - offset - 1);

--- a/core/combiner.hpp
+++ b/core/combiner.hpp
@@ -122,7 +122,7 @@ void sort_buffer_by_key(std::vector<std::pair<KeyT, MsgT>>& combine_buffer) {
 }
 
 // For some reason MSVC does not deal with SFINAE very well
-#ifdef __linux__
+#ifndef _MSC_VER
 void sort_buffer_by_key_msg(std::vector<std::pair<int, int>>& combine_buffer);
 #endif
 

--- a/core/network.cpp
+++ b/core/network.cpp
@@ -18,85 +18,34 @@
 #include <set>
 #include <string>
 
-#ifdef __linux__
-#include <arpa/inet.h>
-#include <ifaddrs.h>
-#include <netdb.h>
-#include <netinet/in.h>
-#include <sys/param.h>
-#include <unistd.h>
-#endif
-#ifdef _WIN32
-#include <Winsock2.h>
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#endif
+#include "boost/asio.hpp"
 
 #include "core/utils.hpp"
 
 namespace husky {
 
 std::string get_hostname() {
-    char hostname[1024];
-    memset(hostname, 0, sizeof(hostname));
-
-#ifdef __linux__
-    gethostname(hostname, 1024);
-#endif
-
-#ifdef _WIN32
-    gethostname(hostname, 1024);
-#endif
-
-    return std::string(hostname);
+    return boost::asio::ip::host_name();
 }
 
-std::string ns_lookup(const std::string& name) {
-    hostent* record = gethostbyname(name.c_str());
-    ASSERT_MSG(record != NULL, (name + " cannot be resolved").c_str());
-    in_addr* address = reinterpret_cast<in_addr*>(record->h_addr);
-    std::string ip_address = inet_ntoa(*address);
+std::vector<std::string> get_ips(const std::string& name) {
+    std::vector<std::string> ips;
 
-    return ip_address;
-}
-
-std::set<std::string> get_self_ips() {
-    std::set<std::string> ips;
-
-#ifdef __linux__
-    struct ifaddrs* ifap;
-    getifaddrs(&ifap);
-
-    char* addr;
-    struct ifaddrs* ifa;
-    struct sockaddr_in* sa;
-    for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
-        if (ifa->ifa_addr->sa_family == AF_INET) {
-            sa = (struct sockaddr_in*) ifa->ifa_addr;
-            addr = inet_ntoa(sa->sin_addr);
-            ips.insert(addr);
-        }
+    boost::asio::io_service io_service;
+    boost::asio::ip::tcp::resolver resolver(io_service);
+    boost::asio::ip::tcp::resolver::query query(name, "");
+    boost::asio::ip::tcp::resolver::iterator iter = resolver.resolve(query);
+    boost::asio::ip::tcp::resolver::iterator end;
+    while(iter != end) {
+        ips.push_back(iter->endpoint().address().to_string());
+        iter++;
     }
 
-    freeifaddrs(ifap);
-#endif
-
-#ifdef _WIN32
-    struct hostent* phe = gethostbyname(get_hostname().c_str());
-
-    for (int i = 0; phe->h_addr_list[i] != 0; ++i) {
-        struct in_addr addr;
-        memcpy(&addr, phe->h_addr_list[i], sizeof(struct in_addr));
-        ips.insert(inet_ntoa(addr));
-    }
-#endif
     return ips;
 }
 
 bool is_local(const std::string& name) {
-    auto ip = ns_lookup(name);
-    auto self_ips = get_self_ips();
-    return self_ips.find(ip) != self_ips.end();
+    return get_ips(get_hostname()) == get_ips(name);
 }
 
 }  // namespace husky

--- a/core/network.hpp
+++ b/core/network.hpp
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <set>
 #include <string>
+#include <vector>
 
 namespace husky {
 
 std::string get_hostname();
-std::string ns_lookup(const std::string& name);
-std::set<std::string> get_self_ips();
+std::vector<std::string> get_ips();
 bool is_local(const std::string& name);
 
 }  // namespace husky


### PR DESCRIPTION
This patch is to better support the three major platforms (Linux, OSX, and Windows).

1. `core/network.{cpp,hpp}` is done in a platform-independent way
2. Combiner specialization is disable only for MSVC. Seems the SFINAE support is not sufficient yet in MSVC.