### PR TITLE
[Core][Mailbox] Fix a potential problem with poll

### DIFF
--- a/base/concurrent_queue.hpp
+++ b/base/concurrent_queue.hpp
@@ -57,6 +57,13 @@ class ConcurrentQueue {
         return element;
     }
 
+    void clear() {
+        operation_mutex_.lock();
+        std::queue<ElementT> tmp;
+        queue_.swap(tmp);
+        operation_mutex_.unlock();
+    }
+
    private:
     int size_ = 0;
     std::mutex operation_mutex_;

--- a/benchmarks/pagerank.cpp
+++ b/benchmarks/pagerank.cpp
@@ -88,8 +88,9 @@ void pagerank() {
         auto t2 = steady_clock::now();
         auto time = duration_cast<duration<double>>(t2 - t1).count();
         if (husky::Context::get_global_tid() == 0)
-            husky::LOG_I << "[Iter" << std::to_string(iter) << "] " << std::to_string(time) << "s elapsed.";
+            husky::LOG_I << "[Iter " << iter << "] " << time << "s elapsed.";
     }
+    husky::list_execute(vertex_list, {&prch}, {}, [](auto&) {});
 }
 
 int main(int argc, char** argv) {

--- a/core/mailbox.hpp
+++ b/core/mailbox.hpp
@@ -54,6 +54,8 @@ class LocalMailbox {
     /// It will return true when there's available incoming communication.
     /// Return false when all incoming communication is received.
     ///
+    /// Please notice that the progress to poll should be strictly nondecreasing.
+    ///
     /// @param channel_id ID of the Channel in interest.
     /// @param progress Progress of the Channel in interest.
     /// @return True when there's available incoming communication. Otherwise
@@ -64,6 +66,8 @@ class LocalMailbox {
     ///
     /// Similar as the poll(int channel_id, int progress) method. However, It
     /// supports multiple Channel-Progress pairs.
+    ///
+    /// Please notice that the progress to poll should be strictly nondecreasing.
     ///
     /// @param[in] channel_progress_pairs Channel-Progress pairs to query.
     /// @param[out] active_idx The index of the pair that has incoming communication.


### PR DESCRIPTION
When users are interleaving the use of two versions of list_execute (i.e., the one with in/out channels and the one without them), some communications through the channels may seem to be be 'missing'. However, actually they are not---it's due to flushing empty communications. This fix prevents such situation.

@Yuzhen11 and @zzxx-husky please check whether you are fine with the change. The only restriction is that now after you poll progress 2 you cannot poll progress 1. Probably I should clear the corresponding `LocalMailbox::in_queue_` as well?