### PR TITLE
[CMake] Fix a problem in finding thrift

### DIFF
--- a/cmake/dep.cmake
+++ b/cmake/dep.cmake
@@ -117,7 +117,7 @@ endif(RT_FOUND)
 
 ### Thrift ###
 
-find_path(THRIFT_INCLUDE_DIR NAMES thrift)
+find_path(THRIFT_INCLUDE_DIR NAMES thrift/Thrift.h)
 find_library(THRIFT_LIBRARY NAMES thrift)
 if (THRIFT_INCLUDE_DIR AND THRIFT_LIBRARY)
     set(THRIFT_FOUND true)


### PR DESCRIPTION
In some environment, the THRIFT_INCLUDE_DIR will be set as "/usr/bin" (or other binary directory) since it also contains a name "thrift". This will mess up the headers and result in build failure in later build phrase.