### PR TITLE
[Aggregator] Fix Initialization of Aggregator Factory

### DIFF
--- a/lib/aggregator.hpp
+++ b/lib/aggregator.hpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #include "base/assert.hpp"
@@ -78,11 +79,11 @@ class AggregatorFactoryBase {
 
    protected:
     static AggregatorFactoryBase& get_factory() {
-        if (factory_ == nullptr) {
-            factory_ = std::shared_ptr<AggregatorFactoryBase>(create_factory());
-            factory_->init_factory();
+        if (s_factory == nullptr) {
+            s_factory = std::shared_ptr<AggregatorFactoryBase>(create_factory());
+            s_factory->init_factory();
         }
-        return *factory_;
+        return *s_factory;
     }
 
     void sync_aggregator_cache();
@@ -174,7 +175,8 @@ class AggregatorFactoryBase {
     std::vector<AggregatorState*> local_aggs_;
     InnerSharedData* shared_data_{nullptr};
 
-    static thread_local std::shared_ptr<AggregatorFactoryBase> factory_;
+    static thread_local std::shared_ptr<AggregatorFactoryBase> s_factory;
+    static std::mutex s_shard_mutex;
 };
 
 // Note for using aggregator:

--- a/lib/aggregator_factory.cpp
+++ b/lib/aggregator_factory.cpp
@@ -27,7 +27,6 @@ namespace husky {
 namespace lib {
 
 using base::BinStream;
-using base::CallOnceEachTime;
 
 AggregatorChannel& AggregatorFactory::get_channel() { return static_cast<AggregatorFactory&>(get_factory()).channel(); }
 
@@ -98,8 +97,7 @@ AggregatorFactory::InnerSharedData* AggregatorFactory::create_shared_data() { re
 void AggregatorFactory::wait_for_others() { shared_->barrier.wait(get_num_local_factory()); }
 
 void AggregatorFactory::call_once(const std::function<void()>& lambda) {
-    static CallOnceEachTime call_once_each_time;
-    call_once_each_time(lambda);
+    shared_->call_once_each_time(lambda);
 }
 
 void AggregatorFactory::init_factory() {

--- a/lib/aggregator_factory.hpp
+++ b/lib/aggregator_factory.hpp
@@ -16,6 +16,7 @@
 
 #include <vector>
 
+#include "base/generation_lock.hpp"
 #include "base/serialization.hpp"
 #include "base/thread_support.hpp"
 #include "core/accessor.hpp"
@@ -28,6 +29,7 @@ namespace lib {
 
 using base::BinStream;
 using base::KBarrier;
+using base::CallOnceEachTime;
 
 class AggregatorFactory : public AggregatorFactoryBase {
    public:
@@ -52,6 +54,7 @@ class AggregatorFactory : public AggregatorFactoryBase {
        public:
         virtual void initialize(AggregatorFactoryBase* factory);
         KBarrier barrier;
+        CallOnceEachTime call_once_each_time;
         std::vector<Accessor<std::vector<AggregatorState*>>> all_local_agg_accessor;
     } * shared_{nullptr};
 


### PR DESCRIPTION
Fix #284

Remove call_once. Use std::mutex for the initialization of aggregator factory and that that works properly for the second initialization.