### PR TITLE
[CMake] Clean up third-party libraries

### DIFF
--- a/cmake/modules/glog.cmake
+++ b/cmake/modules/glog.cmake
@@ -26,11 +26,12 @@ if(GLOG_SEARCH_PATH)
     message(STATUS "  (Library)       ${GLOG_LIBRARY}")
 else(GLOG_SEARCH_PATH)
     include(ExternalProject)
-    set(THIRDPARTY_DIR ${PROJECT_SOURCE_DIR}/third_party)
+    set(THIRDPARTY_DIR ${PROJECT_BINARY_DIR}/third_party)
     set(GLOG_PATCH ${PROJECT_SOURCE_DIR}/third_party/patch/glog-customize-log-format-for-husky.patch)
     ExternalProject_Add(
         glog
         GIT_REPOSITORY "https://github.com/google/glog"
+        GIT_TAG "v0.3.5"
         PREFIX ${THIRDPARTY_DIR}
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${PROJECT_BINARY_DIR}
         CMAKE_ARGS -DWITH_GFLAGS=OFF
@@ -42,9 +43,9 @@ else(GLOG_SEARCH_PATH)
     list(APPEND external_project_dependencies glog)
     set(GLOG_INCLUDE_DIR "${PROJECT_BINARY_DIR}/include")
     if(WIN32)
-        set(GLOG_LIBRARY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/libglog.lib")
+        set(GLOG_LIBRARY "${PROJECT_BINARY_DIR}/lib/libglog.lib")
     else(WIN32)
-        set(GLOG_LIBRARY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/libglog.a")
+        set(GLOG_LIBRARY "${PROJECT_BINARY_DIR}/lib/libglog.a")
     endif(WIN32)
     message(STATUS "GLog will be built as a third party")
     message(STATUS "  (Headers should be)       ${GLOG_INCLUDE_DIR}")

--- a/cmake/modules/gtest.cmake
+++ b/cmake/modules/gtest.cmake
@@ -29,10 +29,11 @@ else(GTEST_SEARCH_PATH)
     find_package(Threads REQUIRED)
     include(ExternalProject)
 
-    set(THIRDPARTY_DIR ${PROJECT_SOURCE_DIR}/third_party)
+    set(THIRDPARTY_DIR ${PROJECT_BINARY_DIR}/third_party)
     ExternalProject_Add(
         gtest
         GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG "release-1.8.0"
         PREFIX ${THIRDPARTY_DIR}
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${PROJECT_BINARY_DIR}
         CMAKE_ARGS -Dgtest_disable_pthreads=ON

--- a/cmake/modules/zeromq.cmake
+++ b/cmake/modules/zeromq.cmake
@@ -30,11 +30,12 @@ if(ZMQ_FOUND)
 else(ZMQ_FOUND)
     message (STATUS "ZeroMQ will be included as a third party:")
     include(ExternalProject)
-    set(THIRDPARTY_DIR ${PROJECT_SOURCE_DIR}/third_party)
+    set(THIRDPARTY_DIR ${PROJECT_BINARY_DIR}/third_party)
     if(NOT ZMQ_INCLUDE_DIR)
         ExternalProject_Add(
             cppzmq
             GIT_REPOSITORY "https://github.com/zeromq/cppzmq"
+            GIT_TAG "v4.2.2"
             PREFIX ${THIRDPARTY_DIR}
             UPDATE_COMMAND ""
             CONFIGURE_COMMAND ""
@@ -48,7 +49,7 @@ else(ZMQ_FOUND)
         ExternalProject_Add(
             libzmq
             GIT_REPOSITORY "https://github.com/zeromq/libzmq"
-            GIT_TAG "v4.2.1"
+            GIT_TAG "v4.2.2"
             PREFIX ${THIRDPARTY_DIR}
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${PROJECT_BINARY_DIR}


### PR DESCRIPTION
1. Use the stable versions of the third-party libraries
2. Move everything generated by cloning and building third-party libraries to the build directory